### PR TITLE
Add FT and Guardian

### DIFF
--- a/.github/workflows/uk-national-newspapers.yml
+++ b/.github/workflows/uk-national-newspapers.yml
@@ -1,0 +1,31 @@
+name: U.K. national newspapers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3,9,15,21 * * *"
+
+jobs:
+  take-screenshot:
+    name: Take screenshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ["ft-uk", "guardian-uk"]
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v2
+
+      - id: screenshot
+        name: Screenshot
+        uses: ./.github/actions/screenshot
+        with:
+          source: ${{ matrix.source }}
+          twitter-consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          twitter-consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          twitter-access-token-key: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          telegram-api-key: ${{ secrets.TELEGRAM_API_KEY }}
+          discord-bot-token: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/sources.csv
+++ b/sources.csv
@@ -9,3 +9,5 @@ bbc,https://www.bbc.com/news,BBC,,,,Europe/London,
 meduzaproject,https://meduza.io/,Meduza,,1800,4000,Europe/Riga,eastern-europe
 laist,https://laist.com/,LAist,,,,America/Los_Angeles,socal
 sdut,https://www.sandiegouniontribune.com/,San Diego Union Tribune,,,,America/Los_Angeles,socal
+ft-uk,https://ft.com/?edition=uk,Financial Times,,,,Europe/London,uk-national-newspapers
+guardian-uk,https://theguardian.com/uk,The Guardian,,,,Europe/London,uk-national-newspapers


### PR DESCRIPTION
This adds the FT and Guardian to the list.

However, the Guardian has a horrible iframe cookie banner across it, the FT has one in the bottom left corner (thanks EU!). There's another PR coming to address this and you might want to close this and merge that one instead, or consider how you want to handle cases like this where web elements get in the way of presentation.