### PR TITLE
Feature/selector removal

### DIFF
--- a/.github/workflows/uk-national-newspapers.yml
+++ b/.github/workflows/uk-national-newspapers.yml
@@ -1,0 +1,31 @@
+name: U.K. national newspapers
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3,9,15,21 * * *"
+
+jobs:
+  take-screenshot:
+    name: Take screenshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: ["ft-uk", "guardian-uk"]
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v2
+
+      - id: screenshot
+        name: Screenshot
+        uses: ./.github/actions/screenshot
+        with:
+          source: ${{ matrix.source }}
+          twitter-consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          twitter-consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          twitter-access-token-key: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          telegram-api-key: ${{ secrets.TELEGRAM_API_KEY }}
+          discord-bot-token: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/shoot.py
+++ b/shoot.py
@@ -31,7 +31,8 @@ def single(handle):
         f"{data['handle']}.jpg",
         data['width'] or DEFAULT_WIDTH,
         data['height'] or DEFAULT_HEIGHT,
-        data['wait'] or DEFAULT_WAIT
+        data['wait'] or DEFAULT_WAIT,
+        data['javascript'] or ''
     )
 
 
@@ -55,8 +56,9 @@ def bundle(slug):
         )
 
 
-def _shoot(url, output, width, height, wait):
+def _shoot(url, output, width, height, wait, javascript):
     logger.debug(f"Shooting {url}")
+    print('for (i in %s) {document.querySelector(i).remove()}' % (javascript))
     subprocess.run([
         "shot-scraper",
         url,
@@ -70,6 +72,8 @@ def _shoot(url, output, width, height, wait):
         height,
         "--wait",
         wait,
+        "--javascript",
+        'for (i of %s) {document.querySelector(i).remove()}' % (javascript)
     ])
 
 

--- a/sources.csv
+++ b/sources.csv
@@ -9,3 +9,5 @@ bbc,https://www.bbc.com/news,BBC,,,,Europe/London,
 meduzaproject,https://meduza.io/,Meduza,,1800,4000,Europe/Riga,eastern-europe
 laist,https://laist.com/,LAist,,,,America/Los_Angeles,socal
 sdut,https://www.sandiegouniontribune.com/,San Diego Union Tribune,,,,America/Los_Angeles,socal
+ft-uk,https://ft.com/?edition=uk,Financial Times,,,,Europe/London,uk-national-newspapers
+guardian-uk,https://theguardian.com/uk,The Guardian,,,,Europe/London,uk-national-newspapers

--- a/sources.csv
+++ b/sources.csv
@@ -1,13 +1,13 @@
-handle,url,name,width,height,wait,timezone,bundle
-latimes,https://www.latimes.com,Los Angeles Times,,2000,,America/Los_Angeles,socal
-nytimes,https://www.nytimes.com,New York Times,,,,America/New_York,us-national-newspapers
-cnn,https://www.cnn.com/,CNN,,,,US/Eastern,us-national-television
-wsj,https://www.wsj.com/,Wall Street Journal,,2000,,America/New_York,us-national-newspapers
-foxnews,https://www.foxnews.com/,Fox News,,,,America/New_York,us-national-television
-kyivindependent,https://kyivindependent.com/,Kyiv Independent,,,,Europe/Kiev,eastern-europe
-bbc,https://www.bbc.com/news,BBC,,,,Europe/London,
-meduzaproject,https://meduza.io/,Meduza,,1800,4000,Europe/Riga,eastern-europe
-laist,https://laist.com/,LAist,,,,America/Los_Angeles,socal
-sdut,https://www.sandiegouniontribune.com/,San Diego Union Tribune,,,,America/Los_Angeles,socal
-ft-uk,https://ft.com/?edition=uk,Financial Times,,,,Europe/London,uk-national-newspapers
-guardian-uk,https://theguardian.com/uk,The Guardian,,,,Europe/London,uk-national-newspapers
+handle,url,name,width,height,wait,timezone,bundle,javascript
+latimes,https://www.latimes.com,Los Angeles Times,,2000,,America/Los_Angeles,socal,
+nytimes,https://www.nytimes.com,New York Times,,,,America/New_York,us-national-newspapers,
+cnn,https://www.cnn.com/,CNN,,,,US/Eastern,us-national-television,
+wsj,https://www.wsj.com/,Wall Street Journal,,2000,,America/New_York,us-national-newspapers,
+foxnews,https://www.foxnews.com/,Fox News,,,,America/New_York,us-national-television,
+kyivindependent,https://kyivindependent.com/,Kyiv Independent,,,,Europe/Kiev,eastern-europe,
+bbc,https://www.bbc.com/news,BBC,,,,Europe/London,,
+meduzaproject,https://meduza.io/,Meduza,,1800,4000,Europe/Riga,eastern-europe,
+laist,https://laist.com/,LAist,,,,America/Los_Angeles,socal,
+sdut,https://www.sandiegouniontribune.com/,San Diego Union Tribune,,,,America/Los_Angeles,socal,
+ft-uk,https://ft.com/?edition=uk,Financial Times,,,,Europe/London,uk-national-newspapers,['.o-cookie-message']
+guardian-uk,https://www.theguardian.com/uk,The Guardian,,,,Europe/London,uk-national-newspapers,"['#sp_message_container_597005','.top-banner-ad-container']"


### PR DESCRIPTION
This adds a new option following the `shot-scraper` documentation to allow custom javascript to be run.

To minimize the effects (and keep the csv readable) I have fixed it to only remove elements listed in the csv, rather than do anything else.

This allows the removal of the kinds of cookie banners like the Guardian, which disrupt the tool, and header ads (which don't seem to display in some cases anyway and waste height).

![image](https://user-images.githubusercontent.com/125273/158234014-1b887153-2f66-4d3d-8fee-cbfc065dafa8.png)

This is an alternative PR to https://github.com/palewire/news-homepages/pull/10

Partial fix for #4 until you can do some kind of DNS or request-level blocking.

