### PR TITLE
feat: add washingtonpost to us-national-newspapers

### DIFF
--- a/.github/workflows/us-national-newspapers.yml
+++ b/.github/workflows/us-national-newspapers.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        source: ["nytimes", "wsj"]
+        source: ["nytimes", "washingtonpost", "wsj"]
     steps:
       - id: checkout
         name: Checkout

--- a/sources.csv
+++ b/sources.csv
@@ -16,3 +16,4 @@ abqbizfirst,https://www.bizjournals.com/albuquerque/,Albuquerque Business First,
 thenewmexican,https://www.santafenewmexican.com/,Santa Fe New Mexican,,2000,,America/Denver,newmexico
 source_nm,https://sourcenm.com/,Source New Mexico,,2000,,America/Denver,newmexico
 CrucesSunNews,https://www.lcsun-news.com/,Las Cruces Sun News,,2000,,America/Denver,newmexico
+washingtonpost,https://www.washingtonpost.com/,The Washington Post,,,,America/New_York,us-national-newspapers


### PR DESCRIPTION
Adds The Washington Post to US National Newspapers bundle.

![washingtonpost](https://user-images.githubusercontent.com/2431045/158278930-5ff4c8dc-114c-4585-bdc1-5d244460349a.jpg)
