### PR TITLE
added bay area websites mercury news, oaklandside and east bay times

### DIFF
--- a/.github/workflows/bayarea.yml
+++ b/.github/workflows/bayarea.yml
@@ -1,0 +1,31 @@
+name: Wisconsin
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 13,1 * * *"
+
+jobs:
+  take-screenshot:
+    name: Take screenshot
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        source: [mercnews, Oaklandside, EastBayTimes]
+    steps:
+      - id: checkout
+        name: Checkout
+        uses: actions/checkout@v2
+
+      - id: screenshot
+        name: Screenshot
+        uses: ./.github/actions/screenshot
+        with:
+          source: ${{ matrix.source }}
+          twitter-consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          twitter-consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          twitter-access-token-key: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
+          twitter-access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          telegram-api-key: ${{ secrets.TELEGRAM_API_KEY }}
+          discord-bot-token: ${{ secrets.DISCORD_BOT_TOKEN }}

--- a/sources.csv
+++ b/sources.csv
@@ -25,3 +25,6 @@ StevensPointJrl,https://www.stevenspointjournal.com/,Stevens Point Journal,,2000
 wausauherald,https://www.wausaudailyherald.com/,Wausau Daily Herald,,2000,,America/Chicago,wisconsin
 htrnews,https://www.htrnews.com/,Manitowoc Herald Times Reporter,,2000,,America/Chicago,wisconsin
 gbpressgazette,https://www.greenbaypressgazette.com/,Green Bay Press-Gazette,,2000,,America/Chicago,wisconsin
+mercnews,https://www.mercurynews.com/,Mercury News,,,,America/Los_Angeles,bayarea
+Oaklandside,https://oaklandside.org/,The Oaklandside,,2000,,America/Los_Angeles,bayarea
+EastBayTimes,https://www.eastbaytimes.com/,East Bay Times,,,,America/Los_Angeles,bayarea


### PR DESCRIPTION
Added mercury news, oaklandside, and east bay times. 

I created a new workflow `bayarea.yml` following the `socal.yml` file. If it's better to just add the handles in the `socal.yml` file since they are the same timezone, happy to move them there. 

I tried adding San Francisco Chronicle, but it was taking a screenshot of a popup-add dimming the homepage so I removed it. Adding the screenshot just for reference.

Mercury News:
![mercnews](https://user-images.githubusercontent.com/21325379/158499380-eae74e99-2d94-4046-8621-4a04a1488a7c.jpg)

EastBayTimes:
![EastBayTimes](https://user-images.githubusercontent.com/21325379/158499387-66fdc70e-b374-4ffa-aedb-781951ae45a6.jpg)

Oaklandside:
![Oaklandside](https://user-images.githubusercontent.com/21325379/158499394-9d4cda12-d74d-433b-b972-624dfd7c4f80.jpg)

San Francisco Chronicle:
![sfchronicle](https://user-images.githubusercontent.com/21325379/158501860-d3141cbe-11d7-4d1e-87e3-20c41ea16a55.jpg)

