### PR TITLE
Adds and fixes The Times (#37)

### DIFF
--- a/newshomepages/sources/javascript/thetimes.js
+++ b/newshomepages/sources/javascript/thetimes.js
@@ -1,6 +1,18 @@
-document.querySelectorAll(
-  '.message-container'
-).forEach(el => el.remove())
+const style = document.createElement('style')
+style.innerHTML = `
+#sp_message_container_523772 {
+  display:none!important
+}
+
+#ad-news {
+  display:none!important
+}
+
+react-edition-personalised-article-rail {
+  display: none!important
+}`
+
+document.head.appendChild(style)
 
 document.querySelectorAll(
   '.type-modal,#ad-header,.Tooltip,#sticky-ad-header'

--- a/newshomepages/sources/sites.csv
+++ b/newshomepages/sources/sites.csv
@@ -29,6 +29,7 @@ Independent,https://www.independent.co.uk/,The Independent,,,,Europe/London,uk-n
 Telegraph,https://www.telegraph.co.uk/,The Telegraph,,,,Europe/London,uk-national-news
 nytimes,https://www.nytimes.com,New York Times,,,,America/New_York,us-national-newspapers
 TheSun,https://www.thesun.co.uk/,The Sun,,,5000,Europe/London,uk-national-news
+TheTimes,https://www.thetimes.co.uk/,The Times,,,,Europe/London,uk-national-news
 USATODAY,https://www.usatoday.com/,USA Today,,2000,,America/New_York,us-national-newspapers
 wsj,https://www.wsj.com/,Wall Street Journal,,2000,,America/New_York,us-national-newspapers
 cnn,https://www.cnn.com/,CNN,,,,US/Eastern,us-national-television


### PR DESCRIPTION
This was a problem because The Times banner instantiates after the JS has run. Adding styles persists through this. Fixes #37 