### PR TITLE
Fix focusing hyperlink

### DIFF
--- a/newshomepages/screenshot.py
+++ b/newshomepages/screenshot.py
@@ -52,7 +52,6 @@ def _screenshot(
         context = playwright.chromium.launch_persistent_context(
             data_dir,
             channel="chrome",
-            headless=False,
             args=[
                 f"--disable-extensions-except={extensions_str}",
                 f"--load-extension={extensions_str}",


### PR DESCRIPTION
Fixed #169.

`headless=False` displays the GUI. As a result, the mouse to focus on a hyperlink.