### PR TITLE
remove tracking consent popin from screenshot of mediapart.fr

### DIFF
--- a/newshomepages/sources/javascript/mediapart.js
+++ b/newshomepages/sources/javascript/mediapart.js
@@ -1,0 +1,1 @@
+document.querySelector('#js-cc-modal').remove()


### PR DESCRIPTION
If you need to backfill, there is also an archive of daily homepages : `https://www.mediapart.fr/journal/une/DDMMYY`. eg.: https://www.mediapart.fr/journal/une/300722