### PR TITLE
Fix Philly; add UT WY

### DIFF
--- a/newshomepages/sources/bundles.csv
+++ b/newshomepages/sources/bundles.csv
@@ -48,7 +48,7 @@ ohio,Ohio,America/New_York,Columbus,region
 oklahoma,Oklahoma,America/Chicago,Oklahoma City,region
 oregon,Oregon,America/Los_Angeles,Portland,region
 pennsylvania,Pennsylvania,America/New_York,Harrisburg,region
-philadelphia,Philadelphia,America/New_York,Independence Hall,region
+philadelphia,Philadelphia,America/New_York,Independence Hall,metro
 rhode-island,Rhode Island,America/New_York,Providence,region
 satire,Satire,America/Los_Angeles,Los Angeles,genre
 science,Science,Europe/London,London,genre
@@ -63,8 +63,10 @@ texas,Texas,America/Chicago,Austin,region
 us-left-wing,U.S. left wing,America/New_York,Washington,genre
 us-national,U.S. national news,America/New_York,New York,genre
 us-right-wing,U.S. right wing,America/New_York,Washington,genre
+utah,Utah,America/Denver,Salt Lake City,region
 vermont,Vermont,America/New_York,Montpelier,region
 virginia,Virginia,America/New_York,Richmond,region
 washington,Washington,America/Los_Angeles,Seattle,region
 west-virginia,West Virginia,America/New_York,Charleston,region
 wisconsin,Wisconsin,America/Chicago,Milwaukee,region
+wyoming,Wyoming,America/Denver,Cheyenne,region


### PR DESCRIPTION
Two states didn't exist in bundles and still don't have sites, but at least stubs out entries. Philly needed to be fixed to "metro" type.

Building to identify what's missing for https://github.com/palewire/news-homepages/issues/287