### PR TITLE
Add a new CLI for downloading a site's robots.txt file

### DIFF
--- a/newshomepages/robotstxt.py
+++ b/newshomepages/robotstxt.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from urllib.parse import urlparse
+
+import click
+import requests
+from retry import retry
+
+from . import utils
+
+# User-Agent used when fetching robots.txt.
+USER_AGENT = "NewsHomepagesBot (https://github.com/palewire/news-homepages)"
+
+
+@click.command()
+@click.argument("handle")
+@click.option("-o", "--output-dir", "output_dir", default="./")
+@click.option("--timeout", "timeout", default="5")
+def cli(handle: str, output_dir: str, timeout: str = "5"):
+    """Save the raw robots.txt of the provided site."""
+    site = utils.get_site(handle)
+
+    # Set the output path
+    output_path = Path(output_dir) / f"{handle.lower()}.robots.txt"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    robotstxt = _get_robotstxt(site["url"], int(timeout))
+    with output_path.open("w+") as f:
+        f.write(robotstxt)
+
+
+@retry(tries=3, delay=5, backoff=2)
+def _get_robotstxt(site_url: str, timeout: int = 180):
+    robotstxt_url = urlparse(site_url)._replace(path="robots.txt").geturl()
+    response = requests.get(
+        robotstxt_url,
+        headers={
+            "User-Agent": USER_AGENT,
+        },
+        timeout=timeout,
+    )
+    return response.text
+
+
+if __name__ == "__main__":
+    cli()

--- a/tests/test_robotstxt.py
+++ b/tests/test_robotstxt.py
@@ -1,0 +1,10 @@
+from click.testing import CliRunner
+
+from newshomepages import robotstxt
+
+
+def test_robotstxt_cli(tmp_path):
+    """Test a single robots.txt request."""
+    runner = CliRunner()
+    result = runner.invoke(robotstxt.cli, ["latimes", "-o", tmp_path])
+    assert result.exit_code == 0


### PR DESCRIPTION
This PR adds a new `robotstxt` CLI for downloading a site's `robots.txt` file. [From twitter](https://twitter.com/palewire/status/1695156419970891933).

```
> pipenv run python -m newshomepages.robotstxt latimes
> head latimes.robots.txt 
User-agent: *
Disallow: /search
Disallow: /recipes/search
Disallow: /changebrowser
Disallow: /thirdpartyservice
Disallow: /*/thirdpartyservice
Disallow: /config/
Disallow: /*/config
Disallow: /dzcfg
Disallow: /*/dzcfg
```

A few open questions I have:
1. Should I also add a CLI under `newshomepages/extract/cli.py`? I'm not sure what the difference is in that directory
2. Where should I add the Internet Archive upload stuff? 
