### PR TITLE
Add CapRadio from Sacramento

### DIFF
--- a/newshomepages/sources/sites.csv
+++ b/newshomepages/sources/sites.csv
@@ -168,6 +168,7 @@ capgaznews,https://www.capitalgazette.com/,Capital Gazette,Annapolis,America/New
 capitalandmain,https://capitalandmain.com/,Capital & Main,Los Angeles,America/Los_Angeles,US,en,socal|california,,
 capitalb_atl,https://atlanta.capitalbnews.org/,Capital B Atlanta,Atlanta,America/New_York,US,en,georgia,,
 capitolnewsil,https://www.capitolnewsillinois.com/,Capitol News Illinois,Springfield,America/Chicago,US,en,,,
+capradionews,https://www.capradio.org/,CapRadio,Sacramento,America/Los_Angeles,US,en,california,,
 cbcnews,https://www.cbc.ca/news,CBC News,Toronto,America/New_York,CA,en,,,
 cbnoficial,https://cbn.globoradio.globo.com/,Rádio CBN,Rio de Janeiro,America/Sao_Paulo,BR,pt,,,
 cbs46,https://www.cbs46.com,CBS46,Atlanta,America/New_York,US,en,georgia,,


### PR DESCRIPTION
Adding CapRadio in Sacramento. I noticed the other Sacramento organizations had `bay-area` as a bundle but I couldn't bring myself to do that. Feel free to add that in when I'm not looking.