### PR TITLE
Re-record test_hyperlinks cassette

### DIFF
--- a/tests/cassettes/test_single.yaml
+++ b/tests/cassettes/test_single.yaml
@@ -1,0 +1,2463 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.1
+    method: GET
+    uri: https://publicsuffix.org/list/public_suffix_list.dat
+  response:
+    body:
+      string: "// This Source Code Form is subject to the terms of the Mozilla Public\n//
+        License, v. 2.0. If a copy of the MPL was not distributed with this\n// file,
+        You can obtain one at https://mozilla.org/MPL/2.0/.\n\n// Please pull this
+        list from, and only from https://publicsuffix.org/list/public_suffix_list.dat,\n//
+        rather than any other VCS sites. Pulling from any other URL is not guaranteed
+        to be supported.\n\n// VERSION: 2026-04-16_05-56-51_UTC\n// COMMIT: d254724e91abd027ba21af72678a69edea76b136\n\n//
+        Instructions on pulling and using this list can be found at https://publicsuffix.org/list/.\n\n//
+        ===BEGIN ICANN DOMAINS===\n\n// ac : http://nic.ac/rules.htm\nac\ncom.ac\nedu.ac\ngov.ac\nmil.ac\nnet.ac\norg.ac\n\n//
+        ad : https://www.iana.org/domains/root/db/ad.html\n// Confirmed by Amadeu
+        Abril i Abril (CORE) <amadeu.abril@corenic.org> 2024-11-17\nad\n\n// ae :
+        https://www.iana.org/domains/root/db/ae.html\nae\nac.ae\nco.ae\ngov.ae\nmil.ae\nnet.ae\norg.ae\nsch.ae\n\n//
+        aero : https://information.aero/registration/policies/dmp\naero\n// 2LDs\nairline.aero\nairport.aero\n//
+        2LDs (currently not accepting registration, seemingly never have)\n// As of
+        2024-07, these are marked as reserved for potential 3LD\n// registrations
+        (clause 11 \"allocated subdomains\" in the 2006 TLD\n// policy), but the relevant
+        industry partners have not opened them up\n// for registration. Current status
+        can be determined from the TLD's\n// policy document: 2LDs that are open for
+        registration must list\n// their policy in the TLD's policy. Any 2LD without
+        such a policy is\n// not open for registrations.\naccident-investigation.aero\naccident-prevention.aero\naerobatic.aero\naeroclub.aero\naerodrome.aero\nagents.aero\nair-surveillance.aero\nair-traffic-control.aero\naircraft.aero\nairtraffic.aero\nambulance.aero\nassociation.aero\nauthor.aero\nballooning.aero\nbroker.aero\ncaa.aero\ncargo.aero\ncatering.aero\ncertification.aero\nchampionship.aero\ncharter.aero\ncivilaviation.aero\nclub.aero\nconference.aero\nconsultant.aero\nconsulting.aero\ncontrol.aero\ncouncil.aero\ncrew.aero\ndesign.aero\ndgca.aero\neducator.aero\nemergency.aero\nengine.aero\nengineer.aero\nentertainment.aero\nequipment.aero\nexchange.aero\nexpress.aero\nfederation.aero\nflight.aero\nfreight.aero\nfuel.aero\ngliding.aero\ngovernment.aero\ngroundhandling.aero\ngroup.aero\nhanggliding.aero\nhomebuilt.aero\ninsurance.aero\njournal.aero\njournalist.aero\nleasing.aero\nlogistics.aero\nmagazine.aero\nmaintenance.aero\nmarketplace.aero\nmedia.aero\nmicrolight.aero\nmodelling.aero\nnavigation.aero\nparachuting.aero\nparagliding.aero\npassenger-association.aero\npilot.aero\npress.aero\nproduction.aero\nrecreation.aero\nrepbody.aero\nres.aero\nresearch.aero\nrotorcraft.aero\nsafety.aero\nscientist.aero\nservices.aero\nshow.aero\nskydiving.aero\nsoftware.aero\nstudent.aero\ntaxi.aero\ntrader.aero\ntrading.aero\ntrainer.aero\nunion.aero\nworkinggroup.aero\nworks.aero\n\n//
+        af : https://www.nic.af/domain-price\naf\ncom.af\nedu.af\ngov.af\nnet.af\norg.af\n\n//
+        ag : http://www.nic.ag/prices.htm\nag\nco.ag\ncom.ag\nnet.ag\nnom.ag\norg.ag\n\n//
+        ai : http://nic.com.ai/\nai\ncom.ai\nnet.ai\noff.ai\norg.ai\n\n// al : http://www.ert.gov.al/ert_alb/faq_det.html?Id=31\nal\ncom.al\nedu.al\ngov.al\nmil.al\nnet.al\norg.al\n\n//
+        am : https://www.amnic.net/policy/en/Policy_EN.pdf\n// Confirmed by ISOC AM
+        <isoc@isoc.am> 2024-11-18\nam\nco.am\ncom.am\ncommune.am\nnet.am\norg.am\n\n//
+        ao : https://www.iana.org/domains/root/db/ao.html\n// https://www.dns.ao/ao/\nao\nco.ao\ned.ao\nedu.ao\ngov.ao\ngv.ao\nit.ao\nog.ao\norg.ao\npb.ao\n\n//
+        aq : https://www.iana.org/domains/root/db/aq.html\naq\n\n// ar : https://nic.ar/es/nic-argentina/normativa\nar\nbet.ar\ncom.ar\ncoop.ar\nedu.ar\ngob.ar\ngov.ar\nint.ar\nmil.ar\nmusica.ar\nmutual.ar\nnet.ar\norg.ar\nseg.ar\nsenasa.ar\ntur.ar\n\n//
+        arpa : https://www.iana.org/domains/root/db/arpa.html\n// Confirmed by registry
+        <iana-questions@icann.org> 2008-06-18\narpa\ne164.arpa\nhome.arpa\nin-addr.arpa\nip6.arpa\niris.arpa\nuri.arpa\nurn.arpa\n\n//
+        as : https://www.iana.org/domains/root/db/as.html\nas\ngov.as\n\n// asia :
+        https://www.iana.org/domains/root/db/asia.html\nasia\n\n// at : https://www.iana.org/domains/root/db/at.html\n//
+        Confirmed by registry <it@nic.at> 2008-06-17\nat\nac.at\nsth.ac.at\nco.at\ngv.at\nor.at\n\n//
+        au : https://www.iana.org/domains/root/db/au.html\n// https://www.auda.org.au/\n//
+        Confirmed by registry <general@auda.org.au> 2025-07-16\nau\n// 2LDs\nasn.au\ncom.au\nedu.au\ngov.au\nid.au\nnet.au\norg.au\n//
+        Historic 2LDs (closed to new registration, but sites still exist)\nconf.au\noz.au\n//
+        CGDNs : https://www.auda.org.au/au-domain-names/the-different-au-domain-names/state-and-territory-domain-names/\nact.au\nnsw.au\nnt.au\nqld.au\nsa.au\ntas.au\nvic.au\nwa.au\n//
+        3LDs\nact.edu.au\ncatholic.edu.au\n// eq.edu.au - Removed at the request of
+        the Queensland Department of Education\nnsw.edu.au\nnt.edu.au\nqld.edu.au\nsa.edu.au\ntas.edu.au\nvic.edu.au\nwa.edu.au\n//
+        act.gov.au - Bug 984824 - Removed at request of Greg Tankard\n// nsw.gov.au
+        - Bug 547985 - Removed at request of <Shae.Donelan@services.nsw.gov.au>\n//
+        nt.gov.au - Bug 940478 - Removed at request of Greg Connors <Greg.Connors@nt.gov.au>\nqld.gov.au\nsa.gov.au\ntas.gov.au\nvic.gov.au\nwa.gov.au\n//
+        4LDs\n// education.tas.edu.au - Removed at the request of the Department of
+        Education Tasmania\n// schools.nsw.edu.au - Removed at the request of the
+        New South Wales Department of Education.\n\n// aw : https://www.iana.org/domains/root/db/aw.html\naw\ncom.aw\n\n//
+        ax : https://www.iana.org/domains/root/db/ax.html\nax\n\n// az : https://www.iana.org/domains/root/db/az.html\n//
+        Confirmed via https://whois.az/?page_id=10 2024-12-11\naz\nbiz.az\nco.az\ncom.az\nedu.az\ngov.az\ninfo.az\nint.az\nmil.az\nname.az\nnet.az\norg.az\npp.az\n//
+        No longer available for registration, however domains exist as of 2024-12-11\n//
+        see https://whois.az/?page_id=783\npro.az\n\n// ba : https://www.iana.org/domains/root/db/ba.html\nba\ncom.ba\nedu.ba\ngov.ba\nmil.ba\nnet.ba\norg.ba\n\n//
+        bb : https://www.iana.org/domains/root/db/bb.html\nbb\nbiz.bb\nco.bb\ncom.bb\nedu.bb\ngov.bb\ninfo.bb\nnet.bb\norg.bb\nstore.bb\ntv.bb\n\n//
+        bd : https://www.iana.org/domains/root/db/bd.html\n// Confirmed by registry
+        <dgm.domain@btcl.gov.bd>\nbd\nac.bd\nai.bd\nco.bd\ncom.bd\nedu.bd\ngov.bd\nid.bd\ninfo.bd\nit.bd\nmil.bd\nnet.bd\norg.bd\nsch.bd\ntv.bd\n\n//
+        be : https://www.iana.org/domains/root/db/be.html\n// Confirmed by registry
+        <tech@dns.be> 2008-06-08\nbe\nac.be\n\n// bf : https://www.iana.org/domains/root/db/bf.html\nbf\ngov.bf\n\n//
+        bg : https://www.iana.org/domains/root/db/bg.html\n// https://www.register.bg/user/static/rules/en/index.html\nbg\n0.bg\n1.bg\n2.bg\n3.bg\n4.bg\n5.bg\n6.bg\n7.bg\n8.bg\n9.bg\na.bg\nb.bg\nc.bg\nd.bg\ne.bg\nf.bg\ng.bg\nh.bg\ni.bg\nj.bg\nk.bg\nl.bg\nm.bg\nn.bg\no.bg\np.bg\nq.bg\nr.bg\ns.bg\nt.bg\nu.bg\nv.bg\nw.bg\nx.bg\ny.bg\nz.bg\n\n//
+        bh : https://www.iana.org/domains/root/db/bh.html\nbh\ncom.bh\nedu.bh\ngov.bh\nnet.bh\norg.bh\n\n//
+        bi : https://www.iana.org/domains/root/db/bi.html\n// http://whois.nic.bi/\nbi\nco.bi\ncom.bi\nedu.bi\nor.bi\norg.bi\n\n//
+        biz : https://www.iana.org/domains/root/db/biz.html\nbiz\n\n// bj : https://nic.bj/bj-suffixes.txt\n//
+        Submitted by registry <contact@nic.bj>\nbj\nafrica.bj\nagro.bj\narchitectes.bj\nassur.bj\navocats.bj\nco.bj\ncom.bj\neco.bj\necono.bj\nedu.bj\ninfo.bj\nloisirs.bj\nmoney.bj\nnet.bj\norg.bj\note.bj\nrestaurant.bj\nresto.bj\ntourism.bj\nuniv.bj\n\n//
+        bm : https://www.bermudanic.bm/domain-registration/index.php\nbm\ncom.bm\nedu.bm\ngov.bm\nnet.bm\norg.bm\n\n//
+        bn : http://www.bnnic.bn/faqs\nbn\ncom.bn\nedu.bn\ngov.bn\nnet.bn\norg.bn\n\n//
+        bo : https://nic.bo\n// Confirmed by registry <soporte@nic.bo> 2024-11-19\nbo\ncom.bo\nedu.bo\ngob.bo\nint.bo\nmil.bo\nnet.bo\norg.bo\ntv.bo\nweb.bo\n//
+        Social Domains\nacademia.bo\nagro.bo\narte.bo\nblog.bo\nbolivia.bo\nciencia.bo\ncooperativa.bo\ndemocracia.bo\ndeporte.bo\necologia.bo\neconomia.bo\nempresa.bo\nindigena.bo\nindustria.bo\ninfo.bo\nmedicina.bo\nmovimiento.bo\nmusica.bo\nnatural.bo\nnombre.bo\nnoticias.bo\npatria.bo\nplurinacional.bo\npolitica.bo\nprofesional.bo\npueblo.bo\nrevista.bo\nsalud.bo\ntecnologia.bo\ntksat.bo\ntransporte.bo\nwiki.bo\n\n//
+        br : http://registro.br/dominio/categoria.html\n// Submitted by registry <fneves@registro.br>\nbr\n9guacu.br\nabc.br\nadm.br\nadv.br\nagr.br\naju.br\nam.br\nanani.br\naparecida.br\napi.br\napp.br\narq.br\nart.br\nato.br\nb.br\nbarueri.br\nbelem.br\nbet.br\nbhz.br\nbib.br\nbio.br\nblog.br\nbmd.br\nboavista.br\nbsb.br\ncampinagrande.br\ncampinas.br\ncaxias.br\ncim.br\ncng.br\ncnt.br\ncom.br\ncontagem.br\ncoop.br\ncoz.br\ncri.br\ncuiaba.br\ncuritiba.br\ndef.br\ndes.br\ndet.br\ndev.br\necn.br\neco.br\nedu.br\nemp.br\nenf.br\neng.br\nesp.br\netc.br\neti.br\nfar.br\nfeira.br\nflog.br\nfloripa.br\nfm.br\nfnd.br\nfortal.br\nfot.br\nfoz.br\nfst.br\ng12.br\ngeo.br\nggf.br\ngoiania.br\ngov.br\n//
+        gov.br 26 states + df https://en.wikipedia.org/wiki/States_of_Brazil\nac.gov.br\nal.gov.br\nam.gov.br\nap.gov.br\nba.gov.br\nce.gov.br\ndf.gov.br\nes.gov.br\ngo.gov.br\nma.gov.br\nmg.gov.br\nms.gov.br\nmt.gov.br\npa.gov.br\npb.gov.br\npe.gov.br\npi.gov.br\npr.gov.br\nrj.gov.br\nrn.gov.br\nro.gov.br\nrr.gov.br\nrs.gov.br\nsc.gov.br\nse.gov.br\nsp.gov.br\nto.gov.br\ngru.br\nia.br\nimb.br\nind.br\ninf.br\njab.br\njampa.br\njdf.br\njoinville.br\njor.br\njus.br\nleg.br\nleilao.br\nlel.br\nlog.br\nlondrina.br\nmacapa.br\nmaceio.br\nmanaus.br\nmaringa.br\nmat.br\nmed.br\nmil.br\nmorena.br\nmp.br\nmus.br\nnatal.br\nnet.br\nniteroi.br\n*.nom.br\nnot.br\nntr.br\nodo.br\nong.br\norg.br\nosasco.br\npalmas.br\npoa.br\nppg.br\npro.br\npsc.br\npsi.br\npvh.br\nqsl.br\nradio.br\nrec.br\nrecife.br\nrep.br\nribeirao.br\nrio.br\nriobranco.br\nriopreto.br\nsalvador.br\nsampa.br\nsantamaria.br\nsantoandre.br\nsaobernardo.br\nsaogonca.br\nseg.br\nsjc.br\nslg.br\nslz.br\nsocial.br\nsorocaba.br\nsrv.br\ntaxi.br\ntc.br\ntec.br\nteo.br\nthe.br\ntmp.br\ntrd.br\ntur.br\ntv.br\nudi.br\nvet.br\nvix.br\nvlog.br\nwiki.br\nxyz.br\nzlg.br\n\n//
+        bs : http://www.nic.bs/rules.html\nbs\ncom.bs\nedu.bs\ngov.bs\nnet.bs\norg.bs\n\n//
+        bt : https://www.iana.org/domains/root/db/bt.html\nbt\ncom.bt\nedu.bt\ngov.bt\nnet.bt\norg.bt\n\n//
+        bv : No registrations at this time.\n// Submitted by registry <jarle@uninett.no>\nbv\n\n//
+        bw : https://www.iana.org/domains/root/db/bw.html\n// https://nic.net.bw/bw-name-structure\nbw\nac.bw\nco.bw\ngov.bw\nnet.bw\norg.bw\n\n//
+        by : https://www.iana.org/domains/root/db/by.html\n// http://tld.by/rules_2006_en.html\n//
+        list of other 2nd level tlds ?\nby\ngov.by\nmil.by\n// Official information
+        does not indicate that com.by is a reserved\n// second-level domain, but it's
+        being used as one (see www.google.com.by and\n// www.yahoo.com.by, for example),
+        so we list it here for safety's sake.\ncom.by\n// http://hoster.by/\nof.by\n\n//
+        bz : https://www.iana.org/domains/root/db/bz.html\n// http://www.belizenic.bz/\nbz\nco.bz\ncom.bz\nedu.bz\ngov.bz\nnet.bz\norg.bz\n\n//
+        ca : https://www.iana.org/domains/root/db/ca.html\nca\n// ca geographical
+        names\nab.ca\nbc.ca\nmb.ca\nnb.ca\nnf.ca\nnl.ca\nns.ca\nnt.ca\nnu.ca\non.ca\npe.ca\nqc.ca\nsk.ca\nyk.ca\n//
+        gc.ca: https://en.wikipedia.org/wiki/.gc.ca\n// see also: http://registry.gc.ca/en/SubdomainFAQ\ngc.ca\n\n//
+        cat : https://www.iana.org/domains/root/db/cat.html\ncat\n\n// cc : https://www.iana.org/domains/root/db/cc.html\ncc\n\n//
+        cd : https://www.iana.org/domains/root/db/cd.html\n// https://www.nic.cd\ncd\ngov.cd\n\n//
+        cf : https://www.iana.org/domains/root/db/cf.html\ncf\n\n// cg : https://www.iana.org/domains/root/db/cg.html\ncg\n\n//
+        ch : https://www.iana.org/domains/root/db/ch.html\nch\n\n// ci : https://www.iana.org/domains/root/db/ci.html\nci\nac.ci\na\xE9roport.ci\nasso.ci\nco.ci\ncom.ci\ned.ci\nedu.ci\ngo.ci\ngouv.ci\nint.ci\nnet.ci\nor.ci\norg.ci\n\n//
+        ck : https://www.iana.org/domains/root/db/ck.html\n*.ck\n!www.ck\n\n// cl
+        : https://www.nic.cl\n// Confirmed by .CL registry <hsalgado@nic.cl>\ncl\nco.cl\ngob.cl\ngov.cl\nmil.cl\n\n//
+        cm : https://www.iana.org/domains/root/db/cm.html plus bug 981927\ncm\nco.cm\ncom.cm\ngov.cm\nnet.cm\n\n//
+        cn : https://www.iana.org/domains/root/db/cn.html\n// Submitted by registry
+        <tanyaling@cnnic.cn>\ncn\nac.cn\ncom.cn\nedu.cn\ngov.cn\nmil.cn\nnet.cn\norg.cn\n\u516C\u53F8.cn\n\u7DB2\u7D61.cn\n\u7F51\u7EDC.cn\n//
+        cn geographic names\nah.cn\nbj.cn\ncq.cn\nfj.cn\ngd.cn\ngs.cn\ngx.cn\ngz.cn\nha.cn\nhb.cn\nhe.cn\nhi.cn\nhk.cn\nhl.cn\nhn.cn\njl.cn\njs.cn\njx.cn\nln.cn\nmo.cn\nnm.cn\nnx.cn\nqh.cn\nsc.cn\nsd.cn\nsh.cn\nsn.cn\nsx.cn\ntj.cn\ntw.cn\nxj.cn\nxz.cn\nyn.cn\nzj.cn\n\n//
+        co : https://www.iana.org/domains/root/db/co.html\n// https://www.cointernet.com.co/como-funciona-un-dominio-restringido\n//
+        Confirmed by registry <gonzalo@cointernet.com.co> 2024-11-18\nco\ncom.co\nedu.co\ngov.co\nmil.co\nnet.co\nnom.co\norg.co\n\n//
+        com : https://www.iana.org/domains/root/db/com.html\ncom\n\n// coop : https://www.iana.org/domains/root/db/coop.html\ncoop\n\n//
+        cr : https://nic.cr/capitulo-1-registro-de-un-nombre-de-dominio/\ncr\nac.cr\nco.cr\ned.cr\nfi.cr\ngo.cr\nor.cr\nsa.cr\n\n//
+        cu : https://www.iana.org/domains/root/db/cu.html\ncu\ncom.cu\nedu.cu\ngob.cu\ninf.cu\nnat.cu\nnet.cu\norg.cu\n\n//
+        cv : https://www.iana.org/domains/root/db/cv.html\n// https://ola.cv/domain-extensions-under-cv/\n//
+        Confirmed by registry <support@ola.cv> 2024-11-26\ncv\ncom.cv\nedu.cv\nid.cv\nint.cv\nnet.cv\nnome.cv\norg.cv\npubl.cv\n\n//
+        cw : https://www.uoc.cw/cw-registry\n// Confirmed by registry <registry@uoc.cw>
+        2024-11-19\ncw\ncom.cw\nedu.cw\nnet.cw\norg.cw\n\n// cx : https://www.iana.org/domains/root/db/cx.html\n//
+        list of other 2nd level tlds ?\ncx\ngov.cx\n\n// cy : http://www.nic.cy/\n//
+        Submitted by Panayiotou Fotia <cydns@ucy.ac.cy>\n// https://nic.cy/wp-content/uploads/2024/01/Create-Request-for-domain-name-registration-1.pdf\ncy\nac.cy\nbiz.cy\ncom.cy\nekloges.cy\ngov.cy\nltd.cy\nmil.cy\nnet.cy\norg.cy\npress.cy\npro.cy\ntm.cy\n\n//
+        cz : https://www.iana.org/domains/root/db/cz.html\n// Confirmed by registry
+        <tech@nic.cz> 2025-08-06\ncz\ngov.cz\n\n// de : https://www.iana.org/domains/root/db/de.html\n//
+        Confirmed by registry <ops@denic.de> (with technical\n// reservations) 2008-07-01\nde\n\n//
+        dj : https://www.iana.org/domains/root/db/dj.html\ndj\n\n// dk : https://www.iana.org/domains/root/db/dk.html\n//
+        Confirmed by registry <robert@dk-hostmaster.dk> 2008-06-17\ndk\n\n// dm :
+        https://www.iana.org/domains/root/db/dm.html\n// https://nic.dm/policies/pdf/DMRulesandGuidelines2024v1.pdf\n//
+        Confirmed by registry <admin@dotdm.dm> 2024-11-19\ndm\nco.dm\ncom.dm\nedu.dm\ngov.dm\nnet.dm\norg.dm\n\n//
+        do : https://www.iana.org/domains/root/db/do.html\ndo\nart.do\ncom.do\nedu.do\ngob.do\ngov.do\nmil.do\nnet.do\norg.do\nsld.do\nweb.do\n\n//
+        dz : http://www.nic.dz/images/pdf_nic/charte.pdf\ndz\nart.dz\nasso.dz\ncom.dz\nedu.dz\ngov.dz\nnet.dz\norg.dz\npol.dz\nsoc.dz\ntm.dz\n\n//
+        ec : https://www.nic.ec/\n// Submitted by registry <infraestructura@nic.ec>\nec\nabg.ec\nadm.ec\nagron.ec\narqt.ec\nart.ec\nbar.ec\nchef.ec\ncom.ec\ncont.ec\ncpa.ec\ncue.ec\ndent.ec\ndgn.ec\ndisco.ec\ndoc.ec\nedu.ec\neng.ec\nesm.ec\nfin.ec\nfot.ec\ngal.ec\ngob.ec\ngov.ec\ngye.ec\nibr.ec\ninfo.ec\nk12.ec\nlat.ec\nloj.ec\nmed.ec\nmil.ec\nmktg.ec\nmon.ec\nnet.ec\nntr.ec\nodont.ec\norg.ec\npro.ec\nprof.ec\npsic.ec\npsiq.ec\npub.ec\nrio.ec\nrrpp.ec\nsal.ec\ntech.ec\ntul.ec\ntur.ec\nuio.ec\nvet.ec\nxxx.ec\n\n//
+        edu : https://www.iana.org/domains/root/db/edu.html\nedu\n\n// ee : https://www.internet.ee/domains/general-domains-and-procedure-for-registration-of-sub-domains-under-general-domains\nee\naip.ee\ncom.ee\nedu.ee\nfie.ee\ngov.ee\nlib.ee\nmed.ee\norg.ee\npri.ee\nriik.ee\n\n//
+        eg : https://www.iana.org/domains/root/db/eg.html\n// https://domain.eg/en/domain-rules/subdomain-names-types/\neg\nac.eg\ncom.eg\nedu.eg\neun.eg\ngov.eg\ninfo.eg\nme.eg\nmil.eg\nname.eg\nnet.eg\norg.eg\nsci.eg\nsport.eg\ntv.eg\n\n//
+        er : https://www.iana.org/domains/root/db/er.html\n*.er\n\n// es : https://www.dominios.es/en\nes\ncom.es\nedu.es\ngob.es\nnom.es\norg.es\n\n//
+        et : https://www.iana.org/domains/root/db/et.html\net\nbiz.et\ncom.et\nedu.et\ngov.et\ninfo.et\nname.et\nnet.et\norg.et\n\n//
+        eu : https://www.iana.org/domains/root/db/eu.html\neu\n\n// fi : https://www.iana.org/domains/root/db/fi.html\nfi\n//
+        aland.fi : https://www.iana.org/domains/root/db/ax.html\n// This domain is
+        being phased out in favor of .ax. As there are still many\n// domains under
+        aland.fi, we still keep it on the list until aland.fi is\n// completely removed.\naland.fi\n\n//
+        fj : https://www.iana.org/domains/root/db/fj.html\nfj\nac.fj\nbiz.fj\ncom.fj\nedu.fj\ngov.fj\nid.fj\ninfo.fj\nmil.fj\nname.fj\nnet.fj\norg.fj\npro.fj\n\n//
+        fk : https://www.iana.org/domains/root/db/fk.html\n*.fk\n\n// fm : https://www.iana.org/domains/root/db/fm.html\nfm\ncom.fm\nedu.fm\nnet.fm\norg.fm\n\n//
+        fo : https://www.iana.org/domains/root/db/fo.html\nfo\n\n// fr : https://www.afnic.fr/
+        https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\nfr\nasso.fr\ncom.fr\ngouv.fr\nnom.fr\nprd.fr\ntm.fr\n//
+        Other SLDs now selfmanaged out of AFNIC range. Former \"domaines sectoriels\",
+        still registration suffixes\navoues.fr\ncci.fr\ngreta.fr\nhuissier-justice.fr\n\n//
+        ga : https://www.iana.org/domains/root/db/ga.html\nga\n\n// gb : This registry
+        is effectively dormant\n// Submitted by registry <Damien.Shaw@ja.net>\ngb\n\n//
+        gd : https://www.iana.org/domains/root/db/gd.html\ngd\nedu.gd\ngov.gd\n\n//
+        ge : https://nic.ge/en/administrator/the-ge-domain-regulations\n// Confirmed
+        by registry <info@nic.ge> 2024-11-20\nge\ncom.ge\nedu.ge\ngov.ge\nnet.ge\norg.ge\npvt.ge\nschool.ge\n\n//
+        gf : https://www.iana.org/domains/root/db/gf.html\ngf\n\n// gg : https://www.channelisles.net/register-1/register-direct\n//
+        Confirmed by registry <nigel@channelisles.net> 2013-11-28\ngg\nco.gg\nnet.gg\norg.gg\n\n//
+        gh : https://www.iana.org/domains/root/db/gh.html\n// https://www.nic.gh/\n//
+        Although domains directly at second level are not possible at the moment,\n//
+        they have been possible for some time and may come back.\ngh\nbiz.gh\ncom.gh\nedu.gh\ngov.gh\nmil.gh\nnet.gh\norg.gh\n\n//
+        gi : http://www.nic.gi/rules.html\ngi\ncom.gi\nedu.gi\ngov.gi\nltd.gi\nmod.gi\norg.gi\n\n//
+        gl : https://www.iana.org/domains/root/db/gl.html\n// http://nic.gl\ngl\nco.gl\ncom.gl\nedu.gl\nnet.gl\norg.gl\n\n//
+        gm : http://www.nic.gm/htmlpages%5Cgm-policy.htm\ngm\n\n// gn : http://psg.com/dns/gn/gn.txt\n//
+        Submitted by registry <randy@psg.com>\ngn\nac.gn\ncom.gn\nedu.gn\ngov.gn\nnet.gn\norg.gn\n\n//
+        gov : https://www.iana.org/domains/root/db/gov.html\ngov\n\n// gp : http://www.nic.gp/index.php?lang=en\ngp\nasso.gp\ncom.gp\nedu.gp\nmobi.gp\nnet.gp\norg.gp\n\n//
+        gq : https://www.iana.org/domains/root/db/gq.html\ngq\n\n// gr : https://www.iana.org/domains/root/db/gr.html\n//
+        Submitted by registry <segred@ics.forth.gr>\ngr\ncom.gr\nedu.gr\ngov.gr\nnet.gr\norg.gr\n\n//
+        gs : https://www.iana.org/domains/root/db/gs.html\ngs\n\n// gt : https://www.gt/sitio/registration_policy.php?lang=en\ngt\ncom.gt\nedu.gt\ngob.gt\nind.gt\nmil.gt\nnet.gt\norg.gt\n\n//
+        gu : http://gadao.gov.gu/register.html\n// University of Guam : https://www.uog.edu\n//
+        Submitted by uognoc@triton.uog.edu\ngu\ncom.gu\nedu.gu\ngov.gu\nguam.gu\ninfo.gu\nnet.gu\norg.gu\nweb.gu\n\n//
+        gw : https://www.iana.org/domains/root/db/gw.html\n// gw : https://nic.gw/regras/\ngw\n\n//
+        gy : https://www.iana.org/domains/root/db/gy.html\n// http://registry.gy/\ngy\nco.gy\ncom.gy\nedu.gy\ngov.gy\nnet.gy\norg.gy\n\n//
+        hk : https://www.hkirc.hk\n// Submitted by registry <hk.tech@hkirc.hk>\nhk\ncom.hk\nedu.hk\ngov.hk\nidv.hk\nnet.hk\norg.hk\n\u4E2A\u4EBA.hk\n\u500B\u4EBA.hk\n\u516C\u53F8.hk\n\u653F\u5E9C.hk\n\u654E\u80B2.hk\n\u6559\u80B2.hk\n\u7B87\u4EBA.hk\n\u7D44\u7E54.hk\n\u7D44\u7EC7.hk\n\u7DB2\u7D61.hk\n\u7DB2\u7EDC.hk\n\u7EC4\u7E54.hk\n\u7EC4\u7EC7.hk\n\u7F51\u7D61.hk\n\u7F51\u7EDC.hk\n\n//
+        hm : https://www.iana.org/domains/root/db/hm.html\nhm\n\n// hn : https://www.iana.org/domains/root/db/hn.html\nhn\ncom.hn\nedu.hn\ngob.hn\nmil.hn\nnet.hn\norg.hn\n\n//
+        hr : http://www.dns.hr/documents/pdf/HRTLD-regulations.pdf\nhr\ncom.hr\nfrom.hr\niz.hr\nname.hr\n\n//
+        ht : http://www.nic.ht/info/charte.cfm\nht\nadult.ht\nart.ht\nasso.ht\ncom.ht\ncoop.ht\nedu.ht\nfirm.ht\ngouv.ht\ninfo.ht\nmed.ht\nnet.ht\norg.ht\nperso.ht\npol.ht\npro.ht\nrel.ht\nshop.ht\n\n//
+        hu : https://www.iana.org/domains/root/db/hu.html\n// Confirmed by registry
+        <pasztor@iszt.hu> 2008-06-12\nhu\n2000.hu\nagrar.hu\nbolt.hu\ncasino.hu\ncity.hu\nco.hu\nerotica.hu\nerotika.hu\nfilm.hu\nforum.hu\ngames.hu\nhotel.hu\ninfo.hu\ningatlan.hu\njogasz.hu\nkonyvelo.hu\nlakas.hu\nmedia.hu\nnews.hu\norg.hu\npriv.hu\nreklam.hu\nsex.hu\nshop.hu\nsport.hu\nsuli.hu\nszex.hu\ntm.hu\ntozsde.hu\nutazas.hu\nvideo.hu\n\n//
+        id : https://www.iana.org/domains/root/db/id.html\nid\nac.id\nbiz.id\nco.id\ndesa.id\ngo.id\nkop.id\nmil.id\nmy.id\nnet.id\nor.id\nponpes.id\nsch.id\nweb.id\n//
+        xn--9tfky.id (<bali>.id, Und-Bali)\n\u1B29\u1B2E\u1B36.id\n\n// ie : https://www.iana.org/domains/root/db/ie.html\nie\ngov.ie\n\n//
+        il : http://www.isoc.org.il/domains/\n// see also: https://en.isoc.org.il/il-cctld/registration-rules\n//
+        ISOC-IL (operated by .il Registry)\nil\nac.il\nco.il\ngov.il\nidf.il\nk12.il\nmuni.il\nnet.il\norg.il\n//
+        xn--4dbrk0ce (\"Israel\", Hebrew) : IL\n\u05D9\u05E9\u05E8\u05D0\u05DC\n//
+        xn--4dbgdty6c.xn--4dbrk0ce.\n\u05D0\u05E7\u05D3\u05DE\u05D9\u05D4.\u05D9\u05E9\u05E8\u05D0\u05DC\n//
+        xn--5dbhl8d.xn--4dbrk0ce.\n\u05D9\u05E9\u05D5\u05D1.\u05D9\u05E9\u05E8\u05D0\u05DC\n//
+        xn--8dbq2a.xn--4dbrk0ce.\n\u05E6\u05D4\u05DC.\u05D9\u05E9\u05E8\u05D0\u05DC\n//
+        xn--hebda8b.xn--4dbrk0ce.\n\u05DE\u05DE\u05E9\u05DC.\u05D9\u05E9\u05E8\u05D0\u05DC\n\n//
+        im : https://www.nic.im/\n// Submitted by registry <info@nic.im>\nim\nac.im\nco.im\nltd.co.im\nplc.co.im\ncom.im\nnet.im\norg.im\ntt.im\ntv.im\n\n//
+        in : https://www.iana.org/domains/root/db/in.html\n// see also: https://registry.in/policies\n//
+        Please note, that nic.in is not an official eTLD, but used by most\n// government
+        institutions.\n// Confirmed by Gaurav Kansal <gaurav.kansal@nic.in> 2025-11-06\nin\n5g.in\n6g.in\nac.in\nai.in\nam.in\nbank.in\nbihar.in\nbiz.in\nbusiness.in\nca.in\ncn.in\nco.in\ncom.in\ncoop.in\ncs.in\ndelhi.in\ndr.in\nedu.in\ner.in\nfin.in\nfirm.in\ngen.in\ngov.in\ngujarat.in\nind.in\ninfo.in\nint.in\ninternet.in\nio.in\nme.in\nmil.in\nnet.in\nnic.in\norg.in\npg.in\npost.in\npro.in\nres.in\ntravel.in\ntv.in\nuk.in\nup.in\nus.in\n\n//
+        info : https://www.iana.org/domains/root/db/info.html\ninfo\n\n// int : https://www.iana.org/domains/root/db/int.html\n//
+        Confirmed by registry <iana-questions@icann.org> 2008-06-18\nint\neu.int\n\n//
+        io : http://www.nic.io/rules.htm\nio\nco.io\ncom.io\nedu.io\ngov.io\nmil.io\nnet.io\nnom.io\norg.io\n\n//
+        iq : http://www.cmc.iq/english/iq/iqregister1.htm\niq\ncom.iq\nedu.iq\ngov.iq\nmil.iq\nnet.iq\norg.iq\n\n//
+        ir : http://www.nic.ir/Terms_and_Conditions_ir,_Appendix_1_Domain_Rules\n//
+        Also see http://www.nic.ir/Internationalized_Domain_Names\n// Two <iran>.ir
+        entries added at request of <tech-team@nic.ir>, 2010-04-16\nir\nac.ir\nco.ir\ngov.ir\nid.ir\nnet.ir\norg.ir\nsch.ir\n//
+        xn--mgba3a4f16a.ir (<iran>.ir, Persian YEH)\n\u0627\u06CC\u0631\u0627\u0646.ir\n//
+        xn--mgba3a4fra.ir (<iran>.ir, Arabic YEH)\n\u0627\u064A\u0631\u0627\u0646.ir\n\n//
+        is : http://www.isnic.is/domain/rules.php\n// Confirmed by registry <marius@isgate.is>
+        2024-11-17\nis\n\n// it : https://www.iana.org/domains/root/db/it.html\n//
+        https://www.nic.it/\nit\nedu.it\ngov.it\n// Regions (3.3.1)\n// https://www.nic.it/en/manage-your-it/forms-and-docs
+        -> \"Assignment and Management of domain names\"\nabr.it\nabruzzo.it\naosta-valley.it\naostavalley.it\nbas.it\nbasilicata.it\ncal.it\ncalabria.it\ncam.it\ncampania.it\nemilia-romagna.it\nemiliaromagna.it\nemr.it\nfriuli-v-giulia.it\nfriuli-ve-giulia.it\nfriuli-vegiulia.it\nfriuli-venezia-giulia.it\nfriuli-veneziagiulia.it\nfriuli-vgiulia.it\nfriuliv-giulia.it\nfriulive-giulia.it\nfriulivegiulia.it\nfriulivenezia-giulia.it\nfriuliveneziagiulia.it\nfriulivgiulia.it\nfvg.it\nlaz.it\nlazio.it\nlig.it\nliguria.it\nlom.it\nlombardia.it\nlombardy.it\nlucania.it\nmar.it\nmarche.it\nmol.it\nmolise.it\npiedmont.it\npiemonte.it\npmn.it\npug.it\npuglia.it\nsar.it\nsardegna.it\nsardinia.it\nsic.it\nsicilia.it\nsicily.it\ntaa.it\ntos.it\ntoscana.it\ntrentin-sud-tirol.it\ntrentin-s\xFCd-tirol.it\ntrentin-sudtirol.it\ntrentin-s\xFCdtirol.it\ntrentin-sued-tirol.it\ntrentin-suedtirol.it\ntrentino.it\ntrentino-a-adige.it\ntrentino-aadige.it\ntrentino-alto-adige.it\ntrentino-altoadige.it\ntrentino-s-tirol.it\ntrentino-stirol.it\ntrentino-sud-tirol.it\ntrentino-s\xFCd-tirol.it\ntrentino-sudtirol.it\ntrentino-s\xFCdtirol.it\ntrentino-sued-tirol.it\ntrentino-suedtirol.it\ntrentinoa-adige.it\ntrentinoaadige.it\ntrentinoalto-adige.it\ntrentinoaltoadige.it\ntrentinos-tirol.it\ntrentinostirol.it\ntrentinosud-tirol.it\ntrentinos\xFCd-tirol.it\ntrentinosudtirol.it\ntrentinos\xFCdtirol.it\ntrentinosued-tirol.it\ntrentinosuedtirol.it\ntrentinsud-tirol.it\ntrentins\xFCd-tirol.it\ntrentinsudtirol.it\ntrentins\xFCdtirol.it\ntrentinsued-tirol.it\ntrentinsuedtirol.it\ntuscany.it\numb.it\numbria.it\nval-d-aosta.it\nval-daosta.it\nvald-aosta.it\nvaldaosta.it\nvalle-aosta.it\nvalle-d-aosta.it\nvalle-daosta.it\nvalleaosta.it\nvalled-aosta.it\nvalledaosta.it\nvallee-aoste.it\nvall\xE9e-aoste.it\nvallee-d-aoste.it\nvall\xE9e-d-aoste.it\nvalleeaoste.it\nvall\xE9eaoste.it\nvalleedaoste.it\nvall\xE9edaoste.it\nvao.it\nvda.it\nven.it\nveneto.it\n//
+        Provinces (3.3.2)\nag.it\nagrigento.it\nal.it\nalessandria.it\nalto-adige.it\naltoadige.it\nan.it\nancona.it\nandria-barletta-trani.it\nandria-trani-barletta.it\nandriabarlettatrani.it\nandriatranibarletta.it\nao.it\naosta.it\naoste.it\nap.it\naq.it\naquila.it\nar.it\narezzo.it\nascoli-piceno.it\nascolipiceno.it\nasti.it\nat.it\nav.it\navellino.it\nba.it\nbalsan.it\nbalsan-sudtirol.it\nbalsan-s\xFCdtirol.it\nbalsan-suedtirol.it\nbari.it\nbarletta-trani-andria.it\nbarlettatraniandria.it\nbelluno.it\nbenevento.it\nbergamo.it\nbg.it\nbi.it\nbiella.it\nbl.it\nbn.it\nbo.it\nbologna.it\nbolzano.it\nbolzano-altoadige.it\nbozen.it\nbozen-sudtirol.it\nbozen-s\xFCdtirol.it\nbozen-suedtirol.it\nbr.it\nbrescia.it\nbrindisi.it\nbs.it\nbt.it\nbulsan.it\nbulsan-sudtirol.it\nbulsan-s\xFCdtirol.it\nbulsan-suedtirol.it\nbz.it\nca.it\ncagliari.it\ncaltanissetta.it\ncampidano-medio.it\ncampidanomedio.it\ncampobasso.it\ncarbonia-iglesias.it\ncarboniaiglesias.it\ncarrara-massa.it\ncarraramassa.it\ncaserta.it\ncatania.it\ncatanzaro.it\ncb.it\nce.it\ncesena-forli.it\ncesena-forl\xEC.it\ncesenaforli.it\ncesenaforl\xEC.it\nch.it\nchieti.it\nci.it\ncl.it\ncn.it\nco.it\ncomo.it\ncosenza.it\ncr.it\ncremona.it\ncrotone.it\ncs.it\nct.it\ncuneo.it\ncz.it\ndell-ogliastra.it\ndellogliastra.it\nen.it\nenna.it\nfc.it\nfe.it\nfermo.it\nferrara.it\nfg.it\nfi.it\nfirenze.it\nflorence.it\nfm.it\nfoggia.it\nforli-cesena.it\nforl\xEC-cesena.it\nforlicesena.it\nforl\xECcesena.it\nfr.it\nfrosinone.it\nge.it\ngenoa.it\ngenova.it\ngo.it\ngorizia.it\ngr.it\ngrosseto.it\niglesias-carbonia.it\niglesiascarbonia.it\nim.it\nimperia.it\nis.it\nisernia.it\nkr.it\nla-spezia.it\nlaquila.it\nlaspezia.it\nlatina.it\nlc.it\nle.it\nlecce.it\nlecco.it\nli.it\nlivorno.it\nlo.it\nlodi.it\nlt.it\nlu.it\nlucca.it\nmacerata.it\nmantova.it\nmassa-carrara.it\nmassacarrara.it\nmatera.it\nmb.it\nmc.it\nme.it\nmedio-campidano.it\nmediocampidano.it\nmessina.it\nmi.it\nmilan.it\nmilano.it\nmn.it\nmo.it\nmodena.it\nmonza.it\nmonza-brianza.it\nmonza-e-della-brianza.it\nmonzabrianza.it\nmonzaebrianza.it\nmonzaedellabrianza.it\nms.it\nmt.it\nna.it\nnaples.it\nnapoli.it\nno.it\nnovara.it\nnu.it\nnuoro.it\nog.it\nogliastra.it\nolbia-tempio.it\nolbiatempio.it\nor.it\noristano.it\not.it\npa.it\npadova.it\npadua.it\npalermo.it\nparma.it\npavia.it\npc.it\npd.it\npe.it\nperugia.it\npesaro-urbino.it\npesarourbino.it\npescara.it\npg.it\npi.it\npiacenza.it\npisa.it\npistoia.it\npn.it\npo.it\npordenone.it\npotenza.it\npr.it\nprato.it\npt.it\npu.it\npv.it\npz.it\nra.it\nragusa.it\nravenna.it\nrc.it\nre.it\nreggio-calabria.it\nreggio-emilia.it\nreggiocalabria.it\nreggioemilia.it\nrg.it\nri.it\nrieti.it\nrimini.it\nrm.it\nrn.it\nro.it\nroma.it\nrome.it\nrovigo.it\nsa.it\nsalerno.it\nsassari.it\nsavona.it\nsi.it\nsiena.it\nsiracusa.it\nso.it\nsondrio.it\nsp.it\nsr.it\nss.it\ns\xFCdtirol.it\nsuedtirol.it\nsv.it\nta.it\ntaranto.it\nte.it\ntempio-olbia.it\ntempioolbia.it\nteramo.it\nterni.it\ntn.it\nto.it\ntorino.it\ntp.it\ntr.it\ntrani-andria-barletta.it\ntrani-barletta-andria.it\ntraniandriabarletta.it\ntranibarlettaandria.it\ntrapani.it\ntrento.it\ntreviso.it\ntrieste.it\nts.it\nturin.it\ntv.it\nud.it\nudine.it\nurbino-pesaro.it\nurbinopesaro.it\nva.it\nvarese.it\nvb.it\nvc.it\nve.it\nvenezia.it\nvenice.it\nverbania.it\nvercelli.it\nverona.it\nvi.it\nvibo-valentia.it\nvibovalentia.it\nvicenza.it\nviterbo.it\nvr.it\nvs.it\nvt.it\nvv.it\n\n//
+        je : https://www.iana.org/domains/root/db/je.html\n// Confirmed by registry
+        <nigel@channelisles.net> 2013-11-28\nje\nco.je\nnet.je\norg.je\n\n// jm :
+        http://www.com.jm/register.html\n*.jm\n\n// jo : https://www.dns.jo/JoFamily.aspx\n//
+        Confirmed by registry <DNS@modee.gov.jo> 2024-11-17\njo\nagri.jo\nai.jo\ncom.jo\nedu.jo\neng.jo\nfm.jo\ngov.jo\nmil.jo\nnet.jo\norg.jo\nper.jo\nphd.jo\nsch.jo\ntv.jo\n\n//
+        jobs : https://www.iana.org/domains/root/db/jobs.html\njobs\n\n// jp : https://www.iana.org/domains/root/db/jp.html\n//
+        http://jprs.co.jp/en/jpdomain.html\n// Confirmed by registry <info@jprs.jp>
+        2024-11-22\njp\n// jp organizational type names\nac.jp\nad.jp\nco.jp\ned.jp\ngo.jp\ngr.jp\nlg.jp\nne.jp\nor.jp\n//
+        jp prefecture type names\naichi.jp\nakita.jp\naomori.jp\nchiba.jp\nehime.jp\nfukui.jp\nfukuoka.jp\nfukushima.jp\ngifu.jp\ngunma.jp\nhiroshima.jp\nhokkaido.jp\nhyogo.jp\nibaraki.jp\nishikawa.jp\niwate.jp\nkagawa.jp\nkagoshima.jp\nkanagawa.jp\nkochi.jp\nkumamoto.jp\nkyoto.jp\nmie.jp\nmiyagi.jp\nmiyazaki.jp\nnagano.jp\nnagasaki.jp\nnara.jp\nniigata.jp\noita.jp\nokayama.jp\nokinawa.jp\nosaka.jp\nsaga.jp\nsaitama.jp\nshiga.jp\nshimane.jp\nshizuoka.jp\ntochigi.jp\ntokushima.jp\ntokyo.jp\ntottori.jp\ntoyama.jp\nwakayama.jp\nyamagata.jp\nyamaguchi.jp\nyamanashi.jp\n\u4E09\u91CD.jp\n\u4EAC\u90FD.jp\n\u4F50\u8CC0.jp\n\u5175\u5EAB.jp\n\u5317\u6D77\u9053.jp\n\u5343\u8449.jp\n\u548C\u6B4C\u5C71.jp\n\u57FC\u7389.jp\n\u5927\u5206.jp\n\u5927\u962A.jp\n\u5948\u826F.jp\n\u5BAE\u57CE.jp\n\u5BAE\u5D0E.jp\n\u5BCC\u5C71.jp\n\u5C71\u53E3.jp\n\u5C71\u5F62.jp\n\u5C71\u68A8.jp\n\u5C90\u961C.jp\n\u5CA1\u5C71.jp\n\u5CA9\u624B.jp\n\u5CF6\u6839.jp\n\u5E83\u5CF6.jp\n\u5FB3\u5CF6.jp\n\u611B\u5A9B.jp\n\u611B\u77E5.jp\n\u65B0\u6F5F.jp\n\u6771\u4EAC.jp\n\u6803\u6728.jp\n\u6C96\u7E04.jp\n\u6ECB\u8CC0.jp\n\u718A\u672C.jp\n\u77F3\u5DDD.jp\n\u795E\u5948\u5DDD.jp\n\u798F\u4E95.jp\n\u798F\u5CA1.jp\n\u798F\u5CF6.jp\n\u79CB\u7530.jp\n\u7FA4\u99AC.jp\n\u8328\u57CE.jp\n\u9577\u5D0E.jp\n\u9577\u91CE.jp\n\u9752\u68EE.jp\n\u9759\u5CA1.jp\n\u9999\u5DDD.jp\n\u9AD8\u77E5.jp\n\u9CE5\u53D6.jp\n\u9E7F\u5150\u5CF6.jp\n//
+        jp geographic type names\n// http://jprs.jp/doc/rule/saisoku-1.html\n// 2024-11-22:
+        JPRS confirmed that jp geographic type names no longer accept new registrations.\n//
+        Once all existing registrations expire (marking full discontinuation), these
+        suffixes\n// will be removed from the PSL.\n*.kawasaki.jp\n!city.kawasaki.jp\n*.kitakyushu.jp\n!city.kitakyushu.jp\n*.kobe.jp\n!city.kobe.jp\n*.nagoya.jp\n!city.nagoya.jp\n*.sapporo.jp\n!city.sapporo.jp\n*.sendai.jp\n!city.sendai.jp\n*.yokohama.jp\n!city.yokohama.jp\n//
+        4th level registration\naisai.aichi.jp\nama.aichi.jp\nanjo.aichi.jp\nasuke.aichi.jp\nchiryu.aichi.jp\nchita.aichi.jp\nfuso.aichi.jp\ngamagori.aichi.jp\nhanda.aichi.jp\nhazu.aichi.jp\nhekinan.aichi.jp\nhigashiura.aichi.jp\nichinomiya.aichi.jp\ninazawa.aichi.jp\ninuyama.aichi.jp\nisshiki.aichi.jp\niwakura.aichi.jp\nkanie.aichi.jp\nkariya.aichi.jp\nkasugai.aichi.jp\nkira.aichi.jp\nkiyosu.aichi.jp\nkomaki.aichi.jp\nkonan.aichi.jp\nkota.aichi.jp\nmihama.aichi.jp\nmiyoshi.aichi.jp\nnishio.aichi.jp\nnisshin.aichi.jp\nobu.aichi.jp\noguchi.aichi.jp\noharu.aichi.jp\nokazaki.aichi.jp\nowariasahi.aichi.jp\nseto.aichi.jp\nshikatsu.aichi.jp\nshinshiro.aichi.jp\nshitara.aichi.jp\ntahara.aichi.jp\ntakahama.aichi.jp\ntobishima.aichi.jp\ntoei.aichi.jp\ntogo.aichi.jp\ntokai.aichi.jp\ntokoname.aichi.jp\ntoyoake.aichi.jp\ntoyohashi.aichi.jp\ntoyokawa.aichi.jp\ntoyone.aichi.jp\ntoyota.aichi.jp\ntsushima.aichi.jp\nyatomi.aichi.jp\nakita.akita.jp\ndaisen.akita.jp\nfujisato.akita.jp\ngojome.akita.jp\nhachirogata.akita.jp\nhappou.akita.jp\nhigashinaruse.akita.jp\nhonjo.akita.jp\nhonjyo.akita.jp\nikawa.akita.jp\nkamikoani.akita.jp\nkamioka.akita.jp\nkatagami.akita.jp\nkazuno.akita.jp\nkitaakita.akita.jp\nkosaka.akita.jp\nkyowa.akita.jp\nmisato.akita.jp\nmitane.akita.jp\nmoriyoshi.akita.jp\nnikaho.akita.jp\nnoshiro.akita.jp\nodate.akita.jp\noga.akita.jp\nogata.akita.jp\nsemboku.akita.jp\nyokote.akita.jp\nyurihonjo.akita.jp\naomori.aomori.jp\ngonohe.aomori.jp\nhachinohe.aomori.jp\nhashikami.aomori.jp\nhiranai.aomori.jp\nhirosaki.aomori.jp\nitayanagi.aomori.jp\nkuroishi.aomori.jp\nmisawa.aomori.jp\nmutsu.aomori.jp\nnakadomari.aomori.jp\nnoheji.aomori.jp\noirase.aomori.jp\nowani.aomori.jp\nrokunohe.aomori.jp\nsannohe.aomori.jp\nshichinohe.aomori.jp\nshingo.aomori.jp\ntakko.aomori.jp\ntowada.aomori.jp\ntsugaru.aomori.jp\ntsuruta.aomori.jp\nabiko.chiba.jp\nasahi.chiba.jp\nchonan.chiba.jp\nchosei.chiba.jp\nchoshi.chiba.jp\nchuo.chiba.jp\nfunabashi.chiba.jp\nfuttsu.chiba.jp\nhanamigawa.chiba.jp\nichihara.chiba.jp\nichikawa.chiba.jp\nichinomiya.chiba.jp\ninzai.chiba.jp\nisumi.chiba.jp\nkamagaya.chiba.jp\nkamogawa.chiba.jp\nkashiwa.chiba.jp\nkatori.chiba.jp\nkatsuura.chiba.jp\nkimitsu.chiba.jp\nkisarazu.chiba.jp\nkozaki.chiba.jp\nkujukuri.chiba.jp\nkyonan.chiba.jp\nmatsudo.chiba.jp\nmidori.chiba.jp\nmihama.chiba.jp\nminamiboso.chiba.jp\nmobara.chiba.jp\nmutsuzawa.chiba.jp\nnagara.chiba.jp\nnagareyama.chiba.jp\nnarashino.chiba.jp\nnarita.chiba.jp\nnoda.chiba.jp\noamishirasato.chiba.jp\nomigawa.chiba.jp\nonjuku.chiba.jp\notaki.chiba.jp\nsakae.chiba.jp\nsakura.chiba.jp\nshimofusa.chiba.jp\nshirako.chiba.jp\nshiroi.chiba.jp\nshisui.chiba.jp\nsodegaura.chiba.jp\nsosa.chiba.jp\ntako.chiba.jp\ntateyama.chiba.jp\ntogane.chiba.jp\ntohnosho.chiba.jp\ntomisato.chiba.jp\nurayasu.chiba.jp\nyachimata.chiba.jp\nyachiyo.chiba.jp\nyokaichiba.chiba.jp\nyokoshibahikari.chiba.jp\nyotsukaido.chiba.jp\nainan.ehime.jp\nhonai.ehime.jp\nikata.ehime.jp\nimabari.ehime.jp\niyo.ehime.jp\nkamijima.ehime.jp\nkihoku.ehime.jp\nkumakogen.ehime.jp\nmasaki.ehime.jp\nmatsuno.ehime.jp\nmatsuyama.ehime.jp\nnamikata.ehime.jp\nniihama.ehime.jp\nozu.ehime.jp\nsaijo.ehime.jp\nseiyo.ehime.jp\nshikokuchuo.ehime.jp\ntobe.ehime.jp\ntoon.ehime.jp\nuchiko.ehime.jp\nuwajima.ehime.jp\nyawatahama.ehime.jp\nechizen.fukui.jp\neiheiji.fukui.jp\nfukui.fukui.jp\nikeda.fukui.jp\nkatsuyama.fukui.jp\nmihama.fukui.jp\nminamiechizen.fukui.jp\nobama.fukui.jp\nohi.fukui.jp\nono.fukui.jp\nsabae.fukui.jp\nsakai.fukui.jp\ntakahama.fukui.jp\ntsuruga.fukui.jp\nwakasa.fukui.jp\nashiya.fukuoka.jp\nbuzen.fukuoka.jp\nchikugo.fukuoka.jp\nchikuho.fukuoka.jp\nchikujo.fukuoka.jp\nchikushino.fukuoka.jp\nchikuzen.fukuoka.jp\nchuo.fukuoka.jp\ndazaifu.fukuoka.jp\nfukuchi.fukuoka.jp\nhakata.fukuoka.jp\nhigashi.fukuoka.jp\nhirokawa.fukuoka.jp\nhisayama.fukuoka.jp\niizuka.fukuoka.jp\ninatsuki.fukuoka.jp\nkaho.fukuoka.jp\nkasuga.fukuoka.jp\nkasuya.fukuoka.jp\nkawara.fukuoka.jp\nkeisen.fukuoka.jp\nkoga.fukuoka.jp\nkurate.fukuoka.jp\nkurogi.fukuoka.jp\nkurume.fukuoka.jp\nminami.fukuoka.jp\nmiyako.fukuoka.jp\nmiyama.fukuoka.jp\nmiyawaka.fukuoka.jp\nmizumaki.fukuoka.jp\nmunakata.fukuoka.jp\nnakagawa.fukuoka.jp\nnakama.fukuoka.jp\nnishi.fukuoka.jp\nnogata.fukuoka.jp\nogori.fukuoka.jp\nokagaki.fukuoka.jp\nokawa.fukuoka.jp\noki.fukuoka.jp\nomuta.fukuoka.jp\nonga.fukuoka.jp\nonojo.fukuoka.jp\noto.fukuoka.jp\nsaigawa.fukuoka.jp\nsasaguri.fukuoka.jp\nshingu.fukuoka.jp\nshinyoshitomi.fukuoka.jp\nshonai.fukuoka.jp\nsoeda.fukuoka.jp\nsue.fukuoka.jp\ntachiarai.fukuoka.jp\ntagawa.fukuoka.jp\ntakata.fukuoka.jp\ntoho.fukuoka.jp\ntoyotsu.fukuoka.jp\ntsuiki.fukuoka.jp\nukiha.fukuoka.jp\numi.fukuoka.jp\nusui.fukuoka.jp\nyamada.fukuoka.jp\nyame.fukuoka.jp\nyanagawa.fukuoka.jp\nyukuhashi.fukuoka.jp\naizubange.fukushima.jp\naizumisato.fukushima.jp\naizuwakamatsu.fukushima.jp\nasakawa.fukushima.jp\nbandai.fukushima.jp\ndate.fukushima.jp\nfukushima.fukushima.jp\nfurudono.fukushima.jp\nfutaba.fukushima.jp\nhanawa.fukushima.jp\nhigashi.fukushima.jp\nhirata.fukushima.jp\nhirono.fukushima.jp\niitate.fukushima.jp\ninawashiro.fukushima.jp\nishikawa.fukushima.jp\niwaki.fukushima.jp\nizumizaki.fukushima.jp\nkagamiishi.fukushima.jp\nkaneyama.fukushima.jp\nkawamata.fukushima.jp\nkitakata.fukushima.jp\nkitashiobara.fukushima.jp\nkoori.fukushima.jp\nkoriyama.fukushima.jp\nkunimi.fukushima.jp\nmiharu.fukushima.jp\nmishima.fukushima.jp\nnamie.fukushima.jp\nnango.fukushima.jp\nnishiaizu.fukushima.jp\nnishigo.fukushima.jp\nokuma.fukushima.jp\nomotego.fukushima.jp\nono.fukushima.jp\notama.fukushima.jp\nsamegawa.fukushima.jp\nshimogo.fukushima.jp\nshirakawa.fukushima.jp\nshowa.fukushima.jp\nsoma.fukushima.jp\nsukagawa.fukushima.jp\ntaishin.fukushima.jp\ntamakawa.fukushima.jp\ntanagura.fukushima.jp\ntenei.fukushima.jp\nyabuki.fukushima.jp\nyamato.fukushima.jp\nyamatsuri.fukushima.jp\nyanaizu.fukushima.jp\nyugawa.fukushima.jp\nanpachi.gifu.jp\nena.gifu.jp\ngifu.gifu.jp\nginan.gifu.jp\ngodo.gifu.jp\ngujo.gifu.jp\nhashima.gifu.jp\nhichiso.gifu.jp\nhida.gifu.jp\nhigashishirakawa.gifu.jp\nibigawa.gifu.jp\nikeda.gifu.jp\nkakamigahara.gifu.jp\nkani.gifu.jp\nkasahara.gifu.jp\nkasamatsu.gifu.jp\nkawaue.gifu.jp\nkitagata.gifu.jp\nmino.gifu.jp\nminokamo.gifu.jp\nmitake.gifu.jp\nmizunami.gifu.jp\nmotosu.gifu.jp\nnakatsugawa.gifu.jp\nogaki.gifu.jp\nsakahogi.gifu.jp\nseki.gifu.jp\nsekigahara.gifu.jp\nshirakawa.gifu.jp\ntajimi.gifu.jp\ntakayama.gifu.jp\ntarui.gifu.jp\ntoki.gifu.jp\ntomika.gifu.jp\nwanouchi.gifu.jp\nyamagata.gifu.jp\nyaotsu.gifu.jp\nyoro.gifu.jp\nannaka.gunma.jp\nchiyoda.gunma.jp\nfujioka.gunma.jp\nhigashiagatsuma.gunma.jp\nisesaki.gunma.jp\nitakura.gunma.jp\nkanna.gunma.jp\nkanra.gunma.jp\nkatashina.gunma.jp\nkawaba.gunma.jp\nkiryu.gunma.jp\nkusatsu.gunma.jp\nmaebashi.gunma.jp\nmeiwa.gunma.jp\nmidori.gunma.jp\nminakami.gunma.jp\nnaganohara.gunma.jp\nnakanojo.gunma.jp\nnanmoku.gunma.jp\nnumata.gunma.jp\noizumi.gunma.jp\nora.gunma.jp\nota.gunma.jp\nshibukawa.gunma.jp\nshimonita.gunma.jp\nshinto.gunma.jp\nshowa.gunma.jp\ntakasaki.gunma.jp\ntakayama.gunma.jp\ntamamura.gunma.jp\ntatebayashi.gunma.jp\ntomioka.gunma.jp\ntsukiyono.gunma.jp\ntsumagoi.gunma.jp\nueno.gunma.jp\nyoshioka.gunma.jp\nasaminami.hiroshima.jp\ndaiwa.hiroshima.jp\netajima.hiroshima.jp\nfuchu.hiroshima.jp\nfukuyama.hiroshima.jp\nhatsukaichi.hiroshima.jp\nhigashihiroshima.hiroshima.jp\nhongo.hiroshima.jp\njinsekikogen.hiroshima.jp\nkaita.hiroshima.jp\nkui.hiroshima.jp\nkumano.hiroshima.jp\nkure.hiroshima.jp\nmihara.hiroshima.jp\nmiyoshi.hiroshima.jp\nnaka.hiroshima.jp\nonomichi.hiroshima.jp\nosakikamijima.hiroshima.jp\notake.hiroshima.jp\nsaka.hiroshima.jp\nsera.hiroshima.jp\nseranishi.hiroshima.jp\nshinichi.hiroshima.jp\nshobara.hiroshima.jp\ntakehara.hiroshima.jp\nabashiri.hokkaido.jp\nabira.hokkaido.jp\naibetsu.hokkaido.jp\nakabira.hokkaido.jp\nakkeshi.hokkaido.jp\nasahikawa.hokkaido.jp\nashibetsu.hokkaido.jp\nashoro.hokkaido.jp\nassabu.hokkaido.jp\natsuma.hokkaido.jp\nbibai.hokkaido.jp\nbiei.hokkaido.jp\nbifuka.hokkaido.jp\nbihoro.hokkaido.jp\nbiratori.hokkaido.jp\nchippubetsu.hokkaido.jp\nchitose.hokkaido.jp\ndate.hokkaido.jp\nebetsu.hokkaido.jp\nembetsu.hokkaido.jp\neniwa.hokkaido.jp\nerimo.hokkaido.jp\nesan.hokkaido.jp\nesashi.hokkaido.jp\nfukagawa.hokkaido.jp\nfukushima.hokkaido.jp\nfurano.hokkaido.jp\nfurubira.hokkaido.jp\nhaboro.hokkaido.jp\nhakodate.hokkaido.jp\nhamatonbetsu.hokkaido.jp\nhidaka.hokkaido.jp\nhigashikagura.hokkaido.jp\nhigashikawa.hokkaido.jp\nhiroo.hokkaido.jp\nhokuryu.hokkaido.jp\nhokuto.hokkaido.jp\nhonbetsu.hokkaido.jp\nhorokanai.hokkaido.jp\nhoronobe.hokkaido.jp\nikeda.hokkaido.jp\nimakane.hokkaido.jp\nishikari.hokkaido.jp\niwamizawa.hokkaido.jp\niwanai.hokkaido.jp\nkamifurano.hokkaido.jp\nkamikawa.hokkaido.jp\nkamishihoro.hokkaido.jp\nkamisunagawa.hokkaido.jp\nkamoenai.hokkaido.jp\nkayabe.hokkaido.jp\nkembuchi.hokkaido.jp\nkikonai.hokkaido.jp\nkimobetsu.hokkaido.jp\nkitahiroshima.hokkaido.jp\nkitami.hokkaido.jp\nkiyosato.hokkaido.jp\nkoshimizu.hokkaido.jp\nkunneppu.hokkaido.jp\nkuriyama.hokkaido.jp\nkuromatsunai.hokkaido.jp\nkushiro.hokkaido.jp\nkutchan.hokkaido.jp\nkyowa.hokkaido.jp\nmashike.hokkaido.jp\nmatsumae.hokkaido.jp\nmikasa.hokkaido.jp\nminamifurano.hokkaido.jp\nmombetsu.hokkaido.jp\nmoseushi.hokkaido.jp\nmukawa.hokkaido.jp\nmuroran.hokkaido.jp\nnaie.hokkaido.jp\nnakagawa.hokkaido.jp\nnakasatsunai.hokkaido.jp\nnakatombetsu.hokkaido.jp\nnanae.hokkaido.jp\nnanporo.hokkaido.jp\nnayoro.hokkaido.jp\nnemuro.hokkaido.jp\nniikappu.hokkaido.jp\nniki.hokkaido.jp\nnishiokoppe.hokkaido.jp\nnoboribetsu.hokkaido.jp\nnumata.hokkaido.jp\nobihiro.hokkaido.jp\nobira.hokkaido.jp\noketo.hokkaido.jp\nokoppe.hokkaido.jp\notaru.hokkaido.jp\notobe.hokkaido.jp\notofuke.hokkaido.jp\notoineppu.hokkaido.jp\noumu.hokkaido.jp\nozora.hokkaido.jp\npippu.hokkaido.jp\nrankoshi.hokkaido.jp\nrebun.hokkaido.jp\nrikubetsu.hokkaido.jp\nrishiri.hokkaido.jp\nrishirifuji.hokkaido.jp\nsaroma.hokkaido.jp\nsarufutsu.hokkaido.jp\nshakotan.hokkaido.jp\nshari.hokkaido.jp\nshibecha.hokkaido.jp\nshibetsu.hokkaido.jp\nshikabe.hokkaido.jp\nshikaoi.hokkaido.jp\nshimamaki.hokkaido.jp\nshimizu.hokkaido.jp\nshimokawa.hokkaido.jp\nshinshinotsu.hokkaido.jp\nshintoku.hokkaido.jp\nshiranuka.hokkaido.jp\nshiraoi.hokkaido.jp\nshiriuchi.hokkaido.jp\nsobetsu.hokkaido.jp\nsunagawa.hokkaido.jp\ntaiki.hokkaido.jp\ntakasu.hokkaido.jp\ntakikawa.hokkaido.jp\ntakinoue.hokkaido.jp\nteshikaga.hokkaido.jp\ntobetsu.hokkaido.jp\ntohma.hokkaido.jp\ntomakomai.hokkaido.jp\ntomari.hokkaido.jp\ntoya.hokkaido.jp\ntoyako.hokkaido.jp\ntoyotomi.hokkaido.jp\ntoyoura.hokkaido.jp\ntsubetsu.hokkaido.jp\ntsukigata.hokkaido.jp\nurakawa.hokkaido.jp\nurausu.hokkaido.jp\nuryu.hokkaido.jp\nutashinai.hokkaido.jp\nwakkanai.hokkaido.jp\nwassamu.hokkaido.jp\nyakumo.hokkaido.jp\nyoichi.hokkaido.jp\naioi.hyogo.jp\nakashi.hyogo.jp\nako.hyogo.jp\namagasaki.hyogo.jp\naogaki.hyogo.jp\nasago.hyogo.jp\nashiya.hyogo.jp\nawaji.hyogo.jp\nfukusaki.hyogo.jp\ngoshiki.hyogo.jp\nharima.hyogo.jp\nhimeji.hyogo.jp\nichikawa.hyogo.jp\ninagawa.hyogo.jp\nitami.hyogo.jp\nkakogawa.hyogo.jp\nkamigori.hyogo.jp\nkamikawa.hyogo.jp\nkasai.hyogo.jp\nkasuga.hyogo.jp\nkawanishi.hyogo.jp\nmiki.hyogo.jp\nminamiawaji.hyogo.jp\nnishinomiya.hyogo.jp\nnishiwaki.hyogo.jp\nono.hyogo.jp\nsanda.hyogo.jp\nsannan.hyogo.jp\nsasayama.hyogo.jp\nsayo.hyogo.jp\nshingu.hyogo.jp\nshinonsen.hyogo.jp\nshiso.hyogo.jp\nsumoto.hyogo.jp\ntaishi.hyogo.jp\ntaka.hyogo.jp\ntakarazuka.hyogo.jp\ntakasago.hyogo.jp\ntakino.hyogo.jp\ntamba.hyogo.jp\ntatsuno.hyogo.jp\ntoyooka.hyogo.jp\nyabu.hyogo.jp\nyashiro.hyogo.jp\nyoka.hyogo.jp\nyokawa.hyogo.jp\nami.ibaraki.jp\nasahi.ibaraki.jp\nbando.ibaraki.jp\nchikusei.ibaraki.jp\ndaigo.ibaraki.jp\nfujishiro.ibaraki.jp\nhitachi.ibaraki.jp\nhitachinaka.ibaraki.jp\nhitachiomiya.ibaraki.jp\nhitachiota.ibaraki.jp\nibaraki.ibaraki.jp\nina.ibaraki.jp\ninashiki.ibaraki.jp\nitako.ibaraki.jp\niwama.ibaraki.jp\njoso.ibaraki.jp\nkamisu.ibaraki.jp\nkasama.ibaraki.jp\nkashima.ibaraki.jp\nkasumigaura.ibaraki.jp\nkoga.ibaraki.jp\nmiho.ibaraki.jp\nmito.ibaraki.jp\nmoriya.ibaraki.jp\nnaka.ibaraki.jp\nnamegata.ibaraki.jp\noarai.ibaraki.jp\nogawa.ibaraki.jp\nomitama.ibaraki.jp\nryugasaki.ibaraki.jp\nsakai.ibaraki.jp\nsakuragawa.ibaraki.jp\nshimodate.ibaraki.jp\nshimotsuma.ibaraki.jp\nshirosato.ibaraki.jp\nsowa.ibaraki.jp\nsuifu.ibaraki.jp\ntakahagi.ibaraki.jp\ntamatsukuri.ibaraki.jp\ntokai.ibaraki.jp\ntomobe.ibaraki.jp\ntone.ibaraki.jp\ntoride.ibaraki.jp\ntsuchiura.ibaraki.jp\ntsukuba.ibaraki.jp\nuchihara.ibaraki.jp\nushiku.ibaraki.jp\nyachiyo.ibaraki.jp\nyamagata.ibaraki.jp\nyawara.ibaraki.jp\nyuki.ibaraki.jp\nanamizu.ishikawa.jp\nhakui.ishikawa.jp\nhakusan.ishikawa.jp\nkaga.ishikawa.jp\nkahoku.ishikawa.jp\nkanazawa.ishikawa.jp\nkawakita.ishikawa.jp\nkomatsu.ishikawa.jp\nnakanoto.ishikawa.jp\nnanao.ishikawa.jp\nnomi.ishikawa.jp\nnonoichi.ishikawa.jp\nnoto.ishikawa.jp\nshika.ishikawa.jp\nsuzu.ishikawa.jp\ntsubata.ishikawa.jp\ntsurugi.ishikawa.jp\nuchinada.ishikawa.jp\nwajima.ishikawa.jp\nfudai.iwate.jp\nfujisawa.iwate.jp\nhanamaki.iwate.jp\nhiraizumi.iwate.jp\nhirono.iwate.jp\nichinohe.iwate.jp\nichinoseki.iwate.jp\niwaizumi.iwate.jp\niwate.iwate.jp\njoboji.iwate.jp\nkamaishi.iwate.jp\nkanegasaki.iwate.jp\nkarumai.iwate.jp\nkawai.iwate.jp\nkitakami.iwate.jp\nkuji.iwate.jp\nkunohe.iwate.jp\nkuzumaki.iwate.jp\nmiyako.iwate.jp\nmizusawa.iwate.jp\nmorioka.iwate.jp\nninohe.iwate.jp\nnoda.iwate.jp\nofunato.iwate.jp\noshu.iwate.jp\notsuchi.iwate.jp\nrikuzentakata.iwate.jp\nshiwa.iwate.jp\nshizukuishi.iwate.jp\nsumita.iwate.jp\ntanohata.iwate.jp\ntono.iwate.jp\nyahaba.iwate.jp\nyamada.iwate.jp\nayagawa.kagawa.jp\nhigashikagawa.kagawa.jp\nkanonji.kagawa.jp\nkotohira.kagawa.jp\nmanno.kagawa.jp\nmarugame.kagawa.jp\nmitoyo.kagawa.jp\nnaoshima.kagawa.jp\nsanuki.kagawa.jp\ntadotsu.kagawa.jp\ntakamatsu.kagawa.jp\ntonosho.kagawa.jp\nuchinomi.kagawa.jp\nutazu.kagawa.jp\nzentsuji.kagawa.jp\nakune.kagoshima.jp\namami.kagoshima.jp\nhioki.kagoshima.jp\nisa.kagoshima.jp\nisen.kagoshima.jp\nizumi.kagoshima.jp\nkagoshima.kagoshima.jp\nkanoya.kagoshima.jp\nkawanabe.kagoshima.jp\nkinko.kagoshima.jp\nkouyama.kagoshima.jp\nmakurazaki.kagoshima.jp\nmatsumoto.kagoshima.jp\nminamitane.kagoshima.jp\nnakatane.kagoshima.jp\nnishinoomote.kagoshima.jp\nsatsumasendai.kagoshima.jp\nsoo.kagoshima.jp\ntarumizu.kagoshima.jp\nyusui.kagoshima.jp\naikawa.kanagawa.jp\natsugi.kanagawa.jp\nayase.kanagawa.jp\nchigasaki.kanagawa.jp\nebina.kanagawa.jp\nfujisawa.kanagawa.jp\nhadano.kanagawa.jp\nhakone.kanagawa.jp\nhiratsuka.kanagawa.jp\nisehara.kanagawa.jp\nkaisei.kanagawa.jp\nkamakura.kanagawa.jp\nkiyokawa.kanagawa.jp\nmatsuda.kanagawa.jp\nminamiashigara.kanagawa.jp\nmiura.kanagawa.jp\nnakai.kanagawa.jp\nninomiya.kanagawa.jp\nodawara.kanagawa.jp\noi.kanagawa.jp\noiso.kanagawa.jp\nsagamihara.kanagawa.jp\nsamukawa.kanagawa.jp\ntsukui.kanagawa.jp\nyamakita.kanagawa.jp\nyamato.kanagawa.jp\nyokosuka.kanagawa.jp\nyugawara.kanagawa.jp\nzama.kanagawa.jp\nzushi.kanagawa.jp\naki.kochi.jp\ngeisei.kochi.jp\nhidaka.kochi.jp\nhigashitsuno.kochi.jp\nino.kochi.jp\nkagami.kochi.jp\nkami.kochi.jp\nkitagawa.kochi.jp\nkochi.kochi.jp\nmihara.kochi.jp\nmotoyama.kochi.jp\nmuroto.kochi.jp\nnahari.kochi.jp\nnakamura.kochi.jp\nnankoku.kochi.jp\nnishitosa.kochi.jp\nniyodogawa.kochi.jp\nochi.kochi.jp\nokawa.kochi.jp\notoyo.kochi.jp\notsuki.kochi.jp\nsakawa.kochi.jp\nsukumo.kochi.jp\nsusaki.kochi.jp\ntosa.kochi.jp\ntosashimizu.kochi.jp\ntoyo.kochi.jp\ntsuno.kochi.jp\numaji.kochi.jp\nyasuda.kochi.jp\nyusuhara.kochi.jp\namakusa.kumamoto.jp\narao.kumamoto.jp\naso.kumamoto.jp\nchoyo.kumamoto.jp\ngyokuto.kumamoto.jp\nkamiamakusa.kumamoto.jp\nkikuchi.kumamoto.jp\nkumamoto.kumamoto.jp\nmashiki.kumamoto.jp\nmifune.kumamoto.jp\nminamata.kumamoto.jp\nminamioguni.kumamoto.jp\nnagasu.kumamoto.jp\nnishihara.kumamoto.jp\noguni.kumamoto.jp\nozu.kumamoto.jp\nsumoto.kumamoto.jp\ntakamori.kumamoto.jp\nuki.kumamoto.jp\nuto.kumamoto.jp\nyamaga.kumamoto.jp\nyamato.kumamoto.jp\nyatsushiro.kumamoto.jp\nayabe.kyoto.jp\nfukuchiyama.kyoto.jp\nhigashiyama.kyoto.jp\nide.kyoto.jp\nine.kyoto.jp\njoyo.kyoto.jp\nkameoka.kyoto.jp\nkamo.kyoto.jp\nkita.kyoto.jp\nkizu.kyoto.jp\nkumiyama.kyoto.jp\nkyotamba.kyoto.jp\nkyotanabe.kyoto.jp\nkyotango.kyoto.jp\nmaizuru.kyoto.jp\nminami.kyoto.jp\nminamiyamashiro.kyoto.jp\nmiyazu.kyoto.jp\nmuko.kyoto.jp\nnagaokakyo.kyoto.jp\nnakagyo.kyoto.jp\nnantan.kyoto.jp\noyamazaki.kyoto.jp\nsakyo.kyoto.jp\nseika.kyoto.jp\ntanabe.kyoto.jp\nuji.kyoto.jp\nujitawara.kyoto.jp\nwazuka.kyoto.jp\nyamashina.kyoto.jp\nyawata.kyoto.jp\nasahi.mie.jp\ninabe.mie.jp\nise.mie.jp\nkameyama.mie.jp\nkawagoe.mie.jp\nkiho.mie.jp\nkisosaki.mie.jp\nkiwa.mie.jp\nkomono.mie.jp\nkumano.mie.jp\nkuwana.mie.jp\nmatsusaka.mie.jp\nmeiwa.mie.jp\nmihama.mie.jp\nminamiise.mie.jp\nmisugi.mie.jp\nmiyama.mie.jp\nnabari.mie.jp\nshima.mie.jp\nsuzuka.mie.jp\ntado.mie.jp\ntaiki.mie.jp\ntaki.mie.jp\ntamaki.mie.jp\ntoba.mie.jp\ntsu.mie.jp\nudono.mie.jp\nureshino.mie.jp\nwatarai.mie.jp\nyokkaichi.mie.jp\nfurukawa.miyagi.jp\nhigashimatsushima.miyagi.jp\nishinomaki.miyagi.jp\niwanuma.miyagi.jp\nkakuda.miyagi.jp\nkami.miyagi.jp\nkawasaki.miyagi.jp\nmarumori.miyagi.jp\nmatsushima.miyagi.jp\nminamisanriku.miyagi.jp\nmisato.miyagi.jp\nmurata.miyagi.jp\nnatori.miyagi.jp\nogawara.miyagi.jp\nohira.miyagi.jp\nonagawa.miyagi.jp\nosaki.miyagi.jp\nrifu.miyagi.jp\nsemine.miyagi.jp\nshibata.miyagi.jp\nshichikashuku.miyagi.jp\nshikama.miyagi.jp\nshiogama.miyagi.jp\nshiroishi.miyagi.jp\ntagajo.miyagi.jp\ntaiwa.miyagi.jp\ntome.miyagi.jp\ntomiya.miyagi.jp\nwakuya.miyagi.jp\nwatari.miyagi.jp\nyamamoto.miyagi.jp\nzao.miyagi.jp\naya.miyazaki.jp\nebino.miyazaki.jp\ngokase.miyazaki.jp\nhyuga.miyazaki.jp\nkadogawa.miyazaki.jp\nkawaminami.miyazaki.jp\nkijo.miyazaki.jp\nkitagawa.miyazaki.jp\nkitakata.miyazaki.jp\nkitaura.miyazaki.jp\nkobayashi.miyazaki.jp\nkunitomi.miyazaki.jp\nkushima.miyazaki.jp\nmimata.miyazaki.jp\nmiyakonojo.miyazaki.jp\nmiyazaki.miyazaki.jp\nmorotsuka.miyazaki.jp\nnichinan.miyazaki.jp\nnishimera.miyazaki.jp\nnobeoka.miyazaki.jp\nsaito.miyazaki.jp\nshiiba.miyazaki.jp\nshintomi.miyazaki.jp\ntakaharu.miyazaki.jp\ntakanabe.miyazaki.jp\ntakazaki.miyazaki.jp\ntsuno.miyazaki.jp\nachi.nagano.jp\nagematsu.nagano.jp\nanan.nagano.jp\naoki.nagano.jp\nasahi.nagano.jp\nazumino.nagano.jp\nchikuhoku.nagano.jp\nchikuma.nagano.jp\nchino.nagano.jp\nfujimi.nagano.jp\nhakuba.nagano.jp\nhara.nagano.jp\nhiraya.nagano.jp\niida.nagano.jp\niijima.nagano.jp\niiyama.nagano.jp\niizuna.nagano.jp\nikeda.nagano.jp\nikusaka.nagano.jp\nina.nagano.jp\nkaruizawa.nagano.jp\nkawakami.nagano.jp\nkiso.nagano.jp\nkisofukushima.nagano.jp\nkitaaiki.nagano.jp\nkomagane.nagano.jp\nkomoro.nagano.jp\nmatsukawa.nagano.jp\nmatsumoto.nagano.jp\nmiasa.nagano.jp\nminamiaiki.nagano.jp\nminamimaki.nagano.jp\nminamiminowa.nagano.jp\nminowa.nagano.jp\nmiyada.nagano.jp\nmiyota.nagano.jp\nmochizuki.nagano.jp\nnagano.nagano.jp\nnagawa.nagano.jp\nnagiso.nagano.jp\nnakagawa.nagano.jp\nnakano.nagano.jp\nnozawaonsen.nagano.jp\nobuse.nagano.jp\nogawa.nagano.jp\nokaya.nagano.jp\nomachi.nagano.jp\nomi.nagano.jp\nookuwa.nagano.jp\nooshika.nagano.jp\notaki.nagano.jp\notari.nagano.jp\nsakae.nagano.jp\nsakaki.nagano.jp\nsaku.nagano.jp\nsakuho.nagano.jp\nshimosuwa.nagano.jp\nshinanomachi.nagano.jp\nshiojiri.nagano.jp\nsuwa.nagano.jp\nsuzaka.nagano.jp\ntakagi.nagano.jp\ntakamori.nagano.jp\ntakayama.nagano.jp\ntateshina.nagano.jp\ntatsuno.nagano.jp\ntogakushi.nagano.jp\ntogura.nagano.jp\ntomi.nagano.jp\nueda.nagano.jp\nwada.nagano.jp\nyamagata.nagano.jp\nyamanouchi.nagano.jp\nyasaka.nagano.jp\nyasuoka.nagano.jp\nchijiwa.nagasaki.jp\nfutsu.nagasaki.jp\ngoto.nagasaki.jp\nhasami.nagasaki.jp\nhirado.nagasaki.jp\niki.nagasaki.jp\nisahaya.nagasaki.jp\nkawatana.nagasaki.jp\nkuchinotsu.nagasaki.jp\nmatsuura.nagasaki.jp\nnagasaki.nagasaki.jp\nobama.nagasaki.jp\nomura.nagasaki.jp\noseto.nagasaki.jp\nsaikai.nagasaki.jp\nsasebo.nagasaki.jp\nseihi.nagasaki.jp\nshimabara.nagasaki.jp\nshinkamigoto.nagasaki.jp\ntogitsu.nagasaki.jp\ntsushima.nagasaki.jp\nunzen.nagasaki.jp\nando.nara.jp\ngose.nara.jp\nheguri.nara.jp\nhigashiyoshino.nara.jp\nikaruga.nara.jp\nikoma.nara.jp\nkamikitayama.nara.jp\nkanmaki.nara.jp\nkashiba.nara.jp\nkashihara.nara.jp\nkatsuragi.nara.jp\nkawai.nara.jp\nkawakami.nara.jp\nkawanishi.nara.jp\nkoryo.nara.jp\nkurotaki.nara.jp\nmitsue.nara.jp\nmiyake.nara.jp\nnara.nara.jp\nnosegawa.nara.jp\noji.nara.jp\nouda.nara.jp\noyodo.nara.jp\nsakurai.nara.jp\nsango.nara.jp\nshimoichi.nara.jp\nshimokitayama.nara.jp\nshinjo.nara.jp\nsoni.nara.jp\ntakatori.nara.jp\ntawaramoto.nara.jp\ntenkawa.nara.jp\ntenri.nara.jp\nuda.nara.jp\nyamatokoriyama.nara.jp\nyamatotakada.nara.jp\nyamazoe.nara.jp\nyoshino.nara.jp\naga.niigata.jp\nagano.niigata.jp\ngosen.niigata.jp\nitoigawa.niigata.jp\nizumozaki.niigata.jp\njoetsu.niigata.jp\nkamo.niigata.jp\nkariwa.niigata.jp\nkashiwazaki.niigata.jp\nminamiuonuma.niigata.jp\nmitsuke.niigata.jp\nmuika.niigata.jp\nmurakami.niigata.jp\nmyoko.niigata.jp\nnagaoka.niigata.jp\nniigata.niigata.jp\nojiya.niigata.jp\nomi.niigata.jp\nsado.niigata.jp\nsanjo.niigata.jp\nseiro.niigata.jp\nseirou.niigata.jp\nsekikawa.niigata.jp\nshibata.niigata.jp\ntagami.niigata.jp\ntainai.niigata.jp\ntochio.niigata.jp\ntokamachi.niigata.jp\ntsubame.niigata.jp\ntsunan.niigata.jp\nuonuma.niigata.jp\nyahiko.niigata.jp\nyoita.niigata.jp\nyuzawa.niigata.jp\nbeppu.oita.jp\nbungoono.oita.jp\nbungotakada.oita.jp\nhasama.oita.jp\nhiji.oita.jp\nhimeshima.oita.jp\nhita.oita.jp\nkamitsue.oita.jp\nkokonoe.oita.jp\nkuju.oita.jp\nkunisaki.oita.jp\nkusu.oita.jp\noita.oita.jp\nsaiki.oita.jp\ntaketa.oita.jp\ntsukumi.oita.jp\nusa.oita.jp\nusuki.oita.jp\nyufu.oita.jp\nakaiwa.okayama.jp\nasakuchi.okayama.jp\nbizen.okayama.jp\nhayashima.okayama.jp\nibara.okayama.jp\nkagamino.okayama.jp\nkasaoka.okayama.jp\nkibichuo.okayama.jp\nkumenan.okayama.jp\nkurashiki.okayama.jp\nmaniwa.okayama.jp\nmisaki.okayama.jp\nnagi.okayama.jp\nniimi.okayama.jp\nnishiawakura.okayama.jp\nokayama.okayama.jp\nsatosho.okayama.jp\nsetouchi.okayama.jp\nshinjo.okayama.jp\nshoo.okayama.jp\nsoja.okayama.jp\ntakahashi.okayama.jp\ntamano.okayama.jp\ntsuyama.okayama.jp\nwake.okayama.jp\nyakage.okayama.jp\naguni.okinawa.jp\nginowan.okinawa.jp\nginoza.okinawa.jp\ngushikami.okinawa.jp\nhaebaru.okinawa.jp\nhigashi.okinawa.jp\nhirara.okinawa.jp\niheya.okinawa.jp\nishigaki.okinawa.jp\nishikawa.okinawa.jp\nitoman.okinawa.jp\nizena.okinawa.jp\nkadena.okinawa.jp\nkin.okinawa.jp\nkitadaito.okinawa.jp\nkitanakagusuku.okinawa.jp\nkumejima.okinawa.jp\nkunigami.okinawa.jp\nminamidaito.okinawa.jp\nmotobu.okinawa.jp\nnago.okinawa.jp\nnaha.okinawa.jp\nnakagusuku.okinawa.jp\nnakijin.okinawa.jp\nnanjo.okinawa.jp\nnishihara.okinawa.jp\nogimi.okinawa.jp\nokinawa.okinawa.jp\nonna.okinawa.jp\nshimoji.okinawa.jp\ntaketomi.okinawa.jp\ntarama.okinawa.jp\ntokashiki.okinawa.jp\ntomigusuku.okinawa.jp\ntonaki.okinawa.jp\nurasoe.okinawa.jp\nuruma.okinawa.jp\nyaese.okinawa.jp\nyomitan.okinawa.jp\nyonabaru.okinawa.jp\nyonaguni.okinawa.jp\nzamami.okinawa.jp\nabeno.osaka.jp\nchihayaakasaka.osaka.jp\nchuo.osaka.jp\ndaito.osaka.jp\nfujiidera.osaka.jp\nhabikino.osaka.jp\nhannan.osaka.jp\nhigashiosaka.osaka.jp\nhigashisumiyoshi.osaka.jp\nhigashiyodogawa.osaka.jp\nhirakata.osaka.jp\nibaraki.osaka.jp\nikeda.osaka.jp\nizumi.osaka.jp\nizumiotsu.osaka.jp\nizumisano.osaka.jp\nkadoma.osaka.jp\nkaizuka.osaka.jp\nkanan.osaka.jp\nkashiwara.osaka.jp\nkatano.osaka.jp\nkawachinagano.osaka.jp\nkishiwada.osaka.jp\nkita.osaka.jp\nkumatori.osaka.jp\nmatsubara.osaka.jp\nminato.osaka.jp\nminoh.osaka.jp\nmisaki.osaka.jp\nmoriguchi.osaka.jp\nneyagawa.osaka.jp\nnishi.osaka.jp\nnose.osaka.jp\nosakasayama.osaka.jp\nsakai.osaka.jp\nsayama.osaka.jp\nsennan.osaka.jp\nsettsu.osaka.jp\nshijonawate.osaka.jp\nshimamoto.osaka.jp\nsuita.osaka.jp\ntadaoka.osaka.jp\ntaishi.osaka.jp\ntajiri.osaka.jp\ntakaishi.osaka.jp\ntakatsuki.osaka.jp\ntondabayashi.osaka.jp\ntoyonaka.osaka.jp\ntoyono.osaka.jp\nyao.osaka.jp\nariake.saga.jp\narita.saga.jp\nfukudomi.saga.jp\ngenkai.saga.jp\nhamatama.saga.jp\nhizen.saga.jp\nimari.saga.jp\nkamimine.saga.jp\nkanzaki.saga.jp\nkaratsu.saga.jp\nkashima.saga.jp\nkitagata.saga.jp\nkitahata.saga.jp\nkiyama.saga.jp\nkouhoku.saga.jp\nkyuragi.saga.jp\nnishiarita.saga.jp\nogi.saga.jp\nomachi.saga.jp\nouchi.saga.jp\nsaga.saga.jp\nshiroishi.saga.jp\ntaku.saga.jp\ntara.saga.jp\ntosu.saga.jp\nyoshinogari.saga.jp\narakawa.saitama.jp\nasaka.saitama.jp\nchichibu.saitama.jp\nfujimi.saitama.jp\nfujimino.saitama.jp\nfukaya.saitama.jp\nhanno.saitama.jp\nhanyu.saitama.jp\nhasuda.saitama.jp\nhatogaya.saitama.jp\nhatoyama.saitama.jp\nhidaka.saitama.jp\nhigashichichibu.saitama.jp\nhigashimatsuyama.saitama.jp\nhonjo.saitama.jp\nina.saitama.jp\niruma.saitama.jp\niwatsuki.saitama.jp\nkamiizumi.saitama.jp\nkamikawa.saitama.jp\nkamisato.saitama.jp\nkasukabe.saitama.jp\nkawagoe.saitama.jp\nkawaguchi.saitama.jp\nkawajima.saitama.jp\nkazo.saitama.jp\nkitamoto.saitama.jp\nkoshigaya.saitama.jp\nkounosu.saitama.jp\nkuki.saitama.jp\nkumagaya.saitama.jp\nmatsubushi.saitama.jp\nminano.saitama.jp\nmisato.saitama.jp\nmiyashiro.saitama.jp\nmiyoshi.saitama.jp\nmoroyama.saitama.jp\nnagatoro.saitama.jp\nnamegawa.saitama.jp\nniiza.saitama.jp\nogano.saitama.jp\nogawa.saitama.jp\nogose.saitama.jp\nokegawa.saitama.jp\nomiya.saitama.jp\notaki.saitama.jp\nranzan.saitama.jp\nryokami.saitama.jp\nsaitama.saitama.jp\nsakado.saitama.jp\nsatte.saitama.jp\nsayama.saitama.jp\nshiki.saitama.jp\nshiraoka.saitama.jp\nsoka.saitama.jp\nsugito.saitama.jp\ntoda.saitama.jp\ntokigawa.saitama.jp\ntokorozawa.saitama.jp\ntsurugashima.saitama.jp\nurawa.saitama.jp\nwarabi.saitama.jp\nyashio.saitama.jp\nyokoze.saitama.jp\nyono.saitama.jp\nyorii.saitama.jp\nyoshida.saitama.jp\nyoshikawa.saitama.jp\nyoshimi.saitama.jp\naisho.shiga.jp\ngamo.shiga.jp\nhigashiomi.shiga.jp\nhikone.shiga.jp\nkoka.shiga.jp\nkonan.shiga.jp\nkosei.shiga.jp\nkoto.shiga.jp\nkusatsu.shiga.jp\nmaibara.shiga.jp\nmoriyama.shiga.jp\nnagahama.shiga.jp\nnishiazai.shiga.jp\nnotogawa.shiga.jp\nomihachiman.shiga.jp\notsu.shiga.jp\nritto.shiga.jp\nryuoh.shiga.jp\ntakashima.shiga.jp\ntakatsuki.shiga.jp\ntorahime.shiga.jp\ntoyosato.shiga.jp\nyasu.shiga.jp\nakagi.shimane.jp\nama.shimane.jp\ngotsu.shimane.jp\nhamada.shimane.jp\nhigashiizumo.shimane.jp\nhikawa.shimane.jp\nhikimi.shimane.jp\nizumo.shimane.jp\nkakinoki.shimane.jp\nmasuda.shimane.jp\nmatsue.shimane.jp\nmisato.shimane.jp\nnishinoshima.shimane.jp\nohda.shimane.jp\nokinoshima.shimane.jp\nokuizumo.shimane.jp\nshimane.shimane.jp\ntamayu.shimane.jp\ntsuwano.shimane.jp\nunnan.shimane.jp\nyakumo.shimane.jp\nyasugi.shimane.jp\nyatsuka.shimane.jp\narai.shizuoka.jp\natami.shizuoka.jp\nfuji.shizuoka.jp\nfujieda.shizuoka.jp\nfujikawa.shizuoka.jp\nfujinomiya.shizuoka.jp\nfukuroi.shizuoka.jp\ngotemba.shizuoka.jp\nhaibara.shizuoka.jp\nhamamatsu.shizuoka.jp\nhigashiizu.shizuoka.jp\nito.shizuoka.jp\niwata.shizuoka.jp\nizu.shizuoka.jp\nizunokuni.shizuoka.jp\nkakegawa.shizuoka.jp\nkannami.shizuoka.jp\nkawanehon.shizuoka.jp\nkawazu.shizuoka.jp\nkikugawa.shizuoka.jp\nkosai.shizuoka.jp\nmakinohara.shizuoka.jp\nmatsuzaki.shizuoka.jp\nminamiizu.shizuoka.jp\nmishima.shizuoka.jp\nmorimachi.shizuoka.jp\nnishiizu.shizuoka.jp\nnumazu.shizuoka.jp\nomaezaki.shizuoka.jp\nshimada.shizuoka.jp\nshimizu.shizuoka.jp\nshimoda.shizuoka.jp\nshizuoka.shizuoka.jp\nsusono.shizuoka.jp\nyaizu.shizuoka.jp\nyoshida.shizuoka.jp\nashikaga.tochigi.jp\nbato.tochigi.jp\nhaga.tochigi.jp\nichikai.tochigi.jp\niwafune.tochigi.jp\nkaminokawa.tochigi.jp\nkanuma.tochigi.jp\nkarasuyama.tochigi.jp\nkuroiso.tochigi.jp\nmashiko.tochigi.jp\nmibu.tochigi.jp\nmoka.tochigi.jp\nmotegi.tochigi.jp\nnasu.tochigi.jp\nnasushiobara.tochigi.jp\nnikko.tochigi.jp\nnishikata.tochigi.jp\nnogi.tochigi.jp\nohira.tochigi.jp\nohtawara.tochigi.jp\noyama.tochigi.jp\nsakura.tochigi.jp\nsano.tochigi.jp\nshimotsuke.tochigi.jp\nshioya.tochigi.jp\ntakanezawa.tochigi.jp\ntochigi.tochigi.jp\ntsuga.tochigi.jp\nujiie.tochigi.jp\nutsunomiya.tochigi.jp\nyaita.tochigi.jp\naizumi.tokushima.jp\nanan.tokushima.jp\nichiba.tokushima.jp\nitano.tokushima.jp\nkainan.tokushima.jp\nkomatsushima.tokushima.jp\nmatsushige.tokushima.jp\nmima.tokushima.jp\nminami.tokushima.jp\nmiyoshi.tokushima.jp\nmugi.tokushima.jp\nnakagawa.tokushima.jp\nnaruto.tokushima.jp\nsanagochi.tokushima.jp\nshishikui.tokushima.jp\ntokushima.tokushima.jp\nwajiki.tokushima.jp\nadachi.tokyo.jp\nakiruno.tokyo.jp\nakishima.tokyo.jp\naogashima.tokyo.jp\narakawa.tokyo.jp\nbunkyo.tokyo.jp\nchiyoda.tokyo.jp\nchofu.tokyo.jp\nchuo.tokyo.jp\nedogawa.tokyo.jp\nfuchu.tokyo.jp\nfussa.tokyo.jp\nhachijo.tokyo.jp\nhachioji.tokyo.jp\nhamura.tokyo.jp\nhigashikurume.tokyo.jp\nhigashimurayama.tokyo.jp\nhigashiyamato.tokyo.jp\nhino.tokyo.jp\nhinode.tokyo.jp\nhinohara.tokyo.jp\ninagi.tokyo.jp\nitabashi.tokyo.jp\nkatsushika.tokyo.jp\nkita.tokyo.jp\nkiyose.tokyo.jp\nkodaira.tokyo.jp\nkoganei.tokyo.jp\nkokubunji.tokyo.jp\nkomae.tokyo.jp\nkoto.tokyo.jp\nkouzushima.tokyo.jp\nkunitachi.tokyo.jp\nmachida.tokyo.jp\nmeguro.tokyo.jp\nminato.tokyo.jp\nmitaka.tokyo.jp\nmizuho.tokyo.jp\nmusashimurayama.tokyo.jp\nmusashino.tokyo.jp\nnakano.tokyo.jp\nnerima.tokyo.jp\nogasawara.tokyo.jp\nokutama.tokyo.jp\nome.tokyo.jp\noshima.tokyo.jp\nota.tokyo.jp\nsetagaya.tokyo.jp\nshibuya.tokyo.jp\nshinagawa.tokyo.jp\nshinjuku.tokyo.jp\nsuginami.tokyo.jp\nsumida.tokyo.jp\ntachikawa.tokyo.jp\ntaito.tokyo.jp\ntama.tokyo.jp\ntoshima.tokyo.jp\nchizu.tottori.jp\nhino.tottori.jp\nkawahara.tottori.jp\nkoge.tottori.jp\nkotoura.tottori.jp\nmisasa.tottori.jp\nnanbu.tottori.jp\nnichinan.tottori.jp\nsakaiminato.tottori.jp\ntottori.tottori.jp\nwakasa.tottori.jp\nyazu.tottori.jp\nyonago.tottori.jp\nasahi.toyama.jp\nfuchu.toyama.jp\nfukumitsu.toyama.jp\nfunahashi.toyama.jp\nhimi.toyama.jp\nimizu.toyama.jp\ninami.toyama.jp\njohana.toyama.jp\nkamiichi.toyama.jp\nkurobe.toyama.jp\nnakaniikawa.toyama.jp\nnamerikawa.toyama.jp\nnanto.toyama.jp\nnyuzen.toyama.jp\noyabe.toyama.jp\ntaira.toyama.jp\ntakaoka.toyama.jp\ntateyama.toyama.jp\ntoga.toyama.jp\ntonami.toyama.jp\ntoyama.toyama.jp\nunazuki.toyama.jp\nuozu.toyama.jp\nyamada.toyama.jp\narida.wakayama.jp\naridagawa.wakayama.jp\ngobo.wakayama.jp\nhashimoto.wakayama.jp\nhidaka.wakayama.jp\nhirogawa.wakayama.jp\ninami.wakayama.jp\niwade.wakayama.jp\nkainan.wakayama.jp\nkamitonda.wakayama.jp\nkatsuragi.wakayama.jp\nkimino.wakayama.jp\nkinokawa.wakayama.jp\nkitayama.wakayama.jp\nkoya.wakayama.jp\nkoza.wakayama.jp\nkozagawa.wakayama.jp\nkudoyama.wakayama.jp\nkushimoto.wakayama.jp\nmihama.wakayama.jp\nmisato.wakayama.jp\nnachikatsuura.wakayama.jp\nshingu.wakayama.jp\nshirahama.wakayama.jp\ntaiji.wakayama.jp\ntanabe.wakayama.jp\nwakayama.wakayama.jp\nyuasa.wakayama.jp\nyura.wakayama.jp\nasahi.yamagata.jp\nfunagata.yamagata.jp\nhigashine.yamagata.jp\niide.yamagata.jp\nkahoku.yamagata.jp\nkaminoyama.yamagata.jp\nkaneyama.yamagata.jp\nkawanishi.yamagata.jp\nmamurogawa.yamagata.jp\nmikawa.yamagata.jp\nmurayama.yamagata.jp\nnagai.yamagata.jp\nnakayama.yamagata.jp\nnanyo.yamagata.jp\nnishikawa.yamagata.jp\nobanazawa.yamagata.jp\noe.yamagata.jp\noguni.yamagata.jp\nohkura.yamagata.jp\noishida.yamagata.jp\nsagae.yamagata.jp\nsakata.yamagata.jp\nsakegawa.yamagata.jp\nshinjo.yamagata.jp\nshirataka.yamagata.jp\nshonai.yamagata.jp\ntakahata.yamagata.jp\ntendo.yamagata.jp\ntozawa.yamagata.jp\ntsuruoka.yamagata.jp\nyamagata.yamagata.jp\nyamanobe.yamagata.jp\nyonezawa.yamagata.jp\nyuza.yamagata.jp\nabu.yamaguchi.jp\nhagi.yamaguchi.jp\nhikari.yamaguchi.jp\nhofu.yamaguchi.jp\niwakuni.yamaguchi.jp\nkudamatsu.yamaguchi.jp\nmitou.yamaguchi.jp\nnagato.yamaguchi.jp\noshima.yamaguchi.jp\nshimonoseki.yamaguchi.jp\nshunan.yamaguchi.jp\ntabuse.yamaguchi.jp\ntokuyama.yamaguchi.jp\ntoyota.yamaguchi.jp\nube.yamaguchi.jp\nyuu.yamaguchi.jp\nchuo.yamanashi.jp\ndoshi.yamanashi.jp\nfuefuki.yamanashi.jp\nfujikawa.yamanashi.jp\nfujikawaguchiko.yamanashi.jp\nfujiyoshida.yamanashi.jp\nhayakawa.yamanashi.jp\nhokuto.yamanashi.jp\nichikawamisato.yamanashi.jp\nkai.yamanashi.jp\nkofu.yamanashi.jp\nkoshu.yamanashi.jp\nkosuge.yamanashi.jp\nminami-alps.yamanashi.jp\nminobu.yamanashi.jp\nnakamichi.yamanashi.jp\nnanbu.yamanashi.jp\nnarusawa.yamanashi.jp\nnirasaki.yamanashi.jp\nnishikatsura.yamanashi.jp\noshino.yamanashi.jp\notsuki.yamanashi.jp\nshowa.yamanashi.jp\ntabayama.yamanashi.jp\ntsuru.yamanashi.jp\nuenohara.yamanashi.jp\nyamanakako.yamanashi.jp\nyamanashi.yamanashi.jp\n\n//
+        ke : http://www.kenic.or.ke/index.php/en/ke-domains/ke-domains\nke\nac.ke\nco.ke\ngo.ke\ninfo.ke\nme.ke\nmobi.ke\nne.ke\nor.ke\nsc.ke\n\n//
+        kg : http://www.domain.kg/dmn_n.html\nkg\ncom.kg\nedu.kg\ngov.kg\nmil.kg\nnet.kg\norg.kg\n\n//
+        kh : https://trc.gov.kh\n// Submitted by khnic@trc.gov.kh\nkh\ncom.kh\nedu.kh\ngov.kh\nnet.kh\norg.kh\n\n//
+        ki : https://www.iana.org/domains/root/db/ki.html\nki\nbiz.ki\ncom.ki\nedu.ki\ngov.ki\ninfo.ki\nnet.ki\norg.ki\n\n//
+        km : https://www.iana.org/domains/root/db/km.html\n// http://www.domaine.km/documents/charte.doc\nkm\nass.km\ncom.km\nedu.km\ngov.km\nmil.km\nnom.km\norg.km\nprd.km\ntm.km\n//
+        These are only mentioned as proposed suggestions at domaine.km, but\n// https://www.iana.org/domains/root/db/km.html
+        says they're available for registration:\nasso.km\ncoop.km\ngouv.km\nmedecin.km\nnotaires.km\npharmaciens.km\npresse.km\nveterinaire.km\n\n//
+        kn : https://www.iana.org/domains/root/db/kn.html\n// http://www.dot.kn/domainRules.html\nkn\nedu.kn\ngov.kn\nnet.kn\norg.kn\n\n//
+        kp : http://www.kcce.kp/en_index.php\nkp\ncom.kp\nedu.kp\ngov.kp\norg.kp\nrep.kp\ntra.kp\n\n//
+        kr : https://www.iana.org/domains/root/db/kr.html\n// see also: https://krnic.kisa.or.kr/jsp/infoboard/law/domBylawsReg.jsp\nkr\nac.kr\nai.kr\nco.kr\nes.kr\ngo.kr\nhs.kr\nio.kr\nit.kr\nkg.kr\nme.kr\nmil.kr\nms.kr\nne.kr\nor.kr\npe.kr\nre.kr\nsc.kr\n//
+        kr geographical names\nbusan.kr\nchungbuk.kr\nchungnam.kr\ndaegu.kr\ndaejeon.kr\ngangwon.kr\ngwangju.kr\ngyeongbuk.kr\ngyeonggi.kr\ngyeongnam.kr\nincheon.kr\njeju.kr\njeonbuk.kr\njeonnam.kr\nseoul.kr\nulsan.kr\n\n//
+        kw : https://www.nic.kw/policies/\n// Confirmed by registry <nic.tech@citra.gov.kw>\nkw\ncom.kw\nedu.kw\nemb.kw\ngov.kw\nind.kw\nnet.kw\norg.kw\n\n//
+        ky : http://www.icta.ky/da_ky_reg_dom.php\n// Confirmed by registry <kysupport@perimeterusa.com>
+        2008-06-17\nky\ncom.ky\nedu.ky\nnet.ky\norg.ky\n\n// kz : https://www.iana.org/domains/root/db/kz.html\n//
+        see also: http://www.nic.kz/rules/index.jsp\nkz\ncom.kz\nedu.kz\ngov.kz\nmil.kz\nnet.kz\norg.kz\n\n//
+        la : https://www.iana.org/domains/root/db/la.html\n// Submitted by registry
+        <gavin.brown@nic.la>\nla\ncom.la\nedu.la\ngov.la\ninfo.la\nint.la\nnet.la\norg.la\nper.la\n\n//
+        lb : https://www.iana.org/domains/root/db/lb.html\n// Submitted by registry
+        <randy@psg.com>\nlb\ncom.lb\nedu.lb\ngov.lb\nnet.lb\norg.lb\n\n// lc : https://www.iana.org/domains/root/db/lc.html\n//
+        see also: http://www.nic.lc/rules.htm\nlc\nco.lc\ncom.lc\nedu.lc\ngov.lc\nnet.lc\norg.lc\n\n//
+        li : https://www.iana.org/domains/root/db/li.html\nli\n\n// lk : https://www.iana.org/domains/root/db/lk.html\nlk\nac.lk\nassn.lk\ncom.lk\nedu.lk\ngov.lk\ngrp.lk\nhotel.lk\nint.lk\nltd.lk\nnet.lk\nngo.lk\norg.lk\nsch.lk\nsoc.lk\nweb.lk\n\n//
+        lr : http://psg.com/dns/lr/lr.txt\n// Submitted by registry <randy@psg.com>\nlr\ncom.lr\nedu.lr\ngov.lr\nnet.lr\norg.lr\n\n//
+        ls : http://www.nic.ls/\n// Confirmed by registry <lsadmin@nic.ls>\nls\nac.ls\nbiz.ls\nco.ls\nedu.ls\ngov.ls\ninfo.ls\nnet.ls\norg.ls\nsc.ls\n\n//
+        lt : https://www.iana.org/domains/root/db/lt.html\nlt\n// gov.lt : http://www.gov.lt/index_en.php\ngov.lt\n\n//
+        lu : http://www.dns.lu/en/\nlu\n\n// lv : https://www.iana.org/domains/root/db/lv.html\nlv\nasn.lv\ncom.lv\nconf.lv\nedu.lv\ngov.lv\nid.lv\nmil.lv\nnet.lv\norg.lv\n\n//
+        ly : http://www.nic.ly/regulations.php\nly\ncom.ly\nedu.ly\ngov.ly\nid.ly\nmed.ly\nnet.ly\norg.ly\nplc.ly\nsch.ly\n\n//
+        ma : https://www.iana.org/domains/root/db/ma.html\n// http://www.anrt.ma/fr/admin/download/upload/file_fr782.pdf\nma\nac.ma\nco.ma\ngov.ma\nnet.ma\norg.ma\npress.ma\n\n//
+        mc : http://www.nic.mc/\nmc\nasso.mc\ntm.mc\n\n// md : https://www.iana.org/domains/root/db/md.html\nmd\n\n//
+        me : https://www.iana.org/domains/root/db/me.html\nme\nac.me\nco.me\nedu.me\ngov.me\nits.me\nnet.me\norg.me\npriv.me\n\n//
+        mg : https://nic.mg\nmg\nco.mg\ncom.mg\nedu.mg\ngov.mg\nmil.mg\nnom.mg\norg.mg\nprd.mg\n\n//
+        mh : https://www.iana.org/domains/root/db/mh.html\nmh\n\n// mil : https://www.iana.org/domains/root/db/mil.html\nmil\n\n//
+        mk : https://www.iana.org/domains/root/db/mk.html\n// see also: http://dns.marnet.net.mk/postapka.php\nmk\ncom.mk\nedu.mk\ngov.mk\ninf.mk\nname.mk\nnet.mk\norg.mk\n\n//
+        ml : https://www.iana.org/domains/root/db/ml.html\n// Confirmed by Boubacar
+        NDIAYE <bndiaye@agetic.gouv.ml> 2024-12-31\nml\nac.ml\nart.ml\nasso.ml\ncom.ml\nedu.ml\ngouv.ml\ngov.ml\ninfo.ml\ninst.ml\nnet.ml\norg.ml\npr.ml\npresse.ml\n\n//
+        mm : https://www.iana.org/domains/root/db/mm.html\n*.mm\n\n// mn : https://www.iana.org/domains/root/db/mn.html\nmn\nedu.mn\ngov.mn\norg.mn\n\n//
+        mo : http://www.monic.net.mo/\nmo\ncom.mo\nedu.mo\ngov.mo\nnet.mo\norg.mo\n\n//
+        mobi : https://www.iana.org/domains/root/db/mobi.html\nmobi\n\n// mp : http://www.dot.mp/\n//
+        Confirmed by registry <dcamacho@saipan.com> 2008-06-17\nmp\n\n// mq : https://www.iana.org/domains/root/db/mq.html\nmq\n\n//
+        mr : https://www.iana.org/domains/root/db/mr.html\nmr\ngov.mr\n\n// ms : https://www.iana.org/domains/root/db/ms.html\nms\ncom.ms\nedu.ms\ngov.ms\nnet.ms\norg.ms\n\n//
+        mt : https://www.nic.org.mt/go/policy\n// Submitted by registry <help@nic.org.mt>\nmt\ncom.mt\nedu.mt\nnet.mt\norg.mt\n\n//
+        mu : https://www.iana.org/domains/root/db/mu.html\nmu\nac.mu\nco.mu\ncom.mu\ngov.mu\nnet.mu\nor.mu\norg.mu\n\n//
+        museum : https://welcome.museum/wp-content/uploads/2018/05/20180525-Registration-Policy-MUSEUM-EN_VF-2.pdf
+        https://welcome.museum/buy-your-dot-museum-2/\nmuseum\n\n// mv : https://www.iana.org/domains/root/db/mv.html\n//
+        \"mv\" included because, contra Wikipedia, google.mv exists.\nmv\naero.mv\nbiz.mv\ncom.mv\ncoop.mv\nedu.mv\ngov.mv\ninfo.mv\nint.mv\nmil.mv\nmuseum.mv\nname.mv\nnet.mv\norg.mv\npro.mv\n\n//
+        mw : http://www.registrar.mw/\nmw\nac.mw\nbiz.mw\nco.mw\ncom.mw\ncoop.mw\nedu.mw\ngov.mw\nint.mw\nnet.mw\norg.mw\n\n//
+        mx : http://www.nic.mx/\n// Submitted by registry <farias@nic.mx>\nmx\ncom.mx\nedu.mx\ngob.mx\nnet.mx\norg.mx\n\n//
+        my : http://www.mynic.my/\n// Available strings: https://mynic.my/resources/domains/buying-a-domain/\nmy\nbiz.my\ncom.my\nedu.my\ngov.my\nmil.my\nname.my\nnet.my\norg.my\n\n//
+        mz : http://www.uem.mz/\n// Submitted by registry <antonio@uem.mz>\nmz\nac.mz\nadv.mz\nco.mz\nedu.mz\ngov.mz\nmil.mz\nnet.mz\norg.mz\n\n//
+        na : http://www.na-nic.com.na/\nna\nalt.na\nco.na\ncom.na\ngov.na\nnet.na\norg.na\n\n//
+        name : http://www.nic.name/\n// Regarding 2LDs: https://github.com/publicsuffix/list/issues/2306\nname\n\n//
+        nc : http://www.cctld.nc/\nnc\nasso.nc\nnom.nc\n\n// ne : https://www.iana.org/domains/root/db/ne.html\nne\n\n//
+        net : https://www.iana.org/domains/root/db/net.html\nnet\n\n// nf : https://www.iana.org/domains/root/db/nf.html\nnf\narts.nf\ncom.nf\nfirm.nf\ninfo.nf\nnet.nf\nother.nf\nper.nf\nrec.nf\nstore.nf\nweb.nf\n\n//
+        ng : http://www.nira.org.ng/index.php/join-us/register-ng-domain/189-nira-slds\nng\ncom.ng\nedu.ng\ngov.ng\ni.ng\nmil.ng\nmobi.ng\nname.ng\nnet.ng\norg.ng\nsch.ng\n\n//
+        ni : http://www.nic.ni/\nni\nac.ni\nbiz.ni\nco.ni\ncom.ni\nedu.ni\ngob.ni\nin.ni\ninfo.ni\nint.ni\nmil.ni\nnet.ni\nnom.ni\norg.ni\nweb.ni\n\n//
+        nl : https://www.iana.org/domains/root/db/nl.html\n// https://www.sidn.nl/\nnl\n\n//
+        no : https://www.norid.no/en/om-domenenavn/regelverk-for-no/\n// Norid geographical
+        second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/\n//
+        Norid category second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/\n//
+        Norid category second-level domains managed by parties other than Norid :
+        https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/\n// RSS
+        feed: https://teknisk.norid.no/en/feed/\nno\n// Norid category second level
+        domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-c/\nfhs.no\nfolkebibl.no\nfylkesbibl.no\nidrett.no\nmuseum.no\npriv.no\nvgs.no\n//
+        Norid category second-level domains managed by parties other than Norid :
+        https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-d/\ndep.no\nherad.no\nkommune.no\nmil.no\nstat.no\n//
+        Norid geographical second level domains : https://www.norid.no/en/om-domenenavn/regelverk-for-no/vedlegg-b/\n//
+        counties\naa.no\nah.no\nbu.no\nfm.no\nhl.no\nhm.no\njan-mayen.no\nmr.no\nnl.no\nnt.no\nof.no\nol.no\noslo.no\nrl.no\nsf.no\nst.no\nsvalbard.no\ntm.no\ntr.no\nva.no\nvf.no\n//
+        primary and lower secondary schools per county\ngs.aa.no\ngs.ah.no\ngs.bu.no\ngs.fm.no\ngs.hl.no\ngs.hm.no\ngs.jan-mayen.no\ngs.mr.no\ngs.nl.no\ngs.nt.no\ngs.of.no\ngs.ol.no\ngs.oslo.no\ngs.rl.no\ngs.sf.no\ngs.st.no\ngs.svalbard.no\ngs.tm.no\ngs.tr.no\ngs.va.no\ngs.vf.no\n//
+        cities\nakrehamn.no\n\xE5krehamn.no\nalgard.no\n\xE5lg\xE5rd.no\narna.no\nbronnoysund.no\nbr\xF8nn\xF8ysund.no\nbrumunddal.no\nbryne.no\ndrobak.no\ndr\xF8bak.no\negersund.no\nfetsund.no\nfloro.no\nflor\xF8.no\nfredrikstad.no\nhokksund.no\nhonefoss.no\nh\xF8nefoss.no\njessheim.no\njorpeland.no\nj\xF8rpeland.no\nkirkenes.no\nkopervik.no\nkrokstadelva.no\nlangevag.no\nlangev\xE5g.no\nleirvik.no\nmjondalen.no\nmj\xF8ndalen.no\nmo-i-rana.no\nmosjoen.no\nmosj\xF8en.no\nnesoddtangen.no\norkanger.no\nosoyro.no\nos\xF8yro.no\nraholt.no\nr\xE5holt.no\nsandnessjoen.no\nsandnessj\xF8en.no\nskedsmokorset.no\nslattum.no\nspjelkavik.no\nstathelle.no\nstavern.no\nstjordalshalsen.no\nstj\xF8rdalshalsen.no\ntananger.no\ntranby.no\nvossevangen.no\n//
+        communities\naarborte.no\naejrie.no\nafjord.no\n\xE5fjord.no\nagdenes.no\nnes.akershus.no\naknoluokta.no\n\xE1k\u014Boluokta.no\nal.no\n\xE5l.no\nalaheadju.no\n\xE1laheadju.no\nalesund.no\n\xE5lesund.no\nalstahaug.no\nalta.no\n\xE1lt\xE1.no\nalvdal.no\namli.no\n\xE5mli.no\namot.no\n\xE5mot.no\nandasuolo.no\nandebu.no\nandoy.no\nand\xF8y.no\nardal.no\n\xE5rdal.no\naremark.no\narendal.no\n\xE5s.no\naseral.no\n\xE5seral.no\nasker.no\naskim.no\naskoy.no\nask\xF8y.no\naskvoll.no\nasnes.no\n\xE5snes.no\naudnedaln.no\naukra.no\naure.no\naurland.no\naurskog-holand.no\naurskog-h\xF8land.no\naustevoll.no\naustrheim.no\naveroy.no\naver\xF8y.no\nbadaddja.no\nb\xE5d\xE5ddj\xE5.no\nb\xE6rum.no\nbahcavuotna.no\nb\xE1hcavuotna.no\nbahccavuotna.no\nb\xE1hccavuotna.no\nbaidar.no\nb\xE1id\xE1r.no\nbajddar.no\nb\xE1jddar.no\nbalat.no\nb\xE1l\xE1t.no\nbalestrand.no\nballangen.no\nbalsfjord.no\nbamble.no\nbardu.no\nbarum.no\nbatsfjord.no\nb\xE5tsfjord.no\nbearalvahki.no\nbearalv\xE1hki.no\nbeardu.no\nbeiarn.no\nberg.no\nbergen.no\nberlevag.no\nberlev\xE5g.no\nbievat.no\nbiev\xE1t.no\nbindal.no\nbirkenes.no\nbjerkreim.no\nbjugn.no\nbodo.no\nbod\xF8.no\nbokn.no\nbomlo.no\nb\xF8mlo.no\nbremanger.no\nbronnoy.no\nbr\xF8nn\xF8y.no\nbudejju.no\nnes.buskerud.no\nbygland.no\nbykle.no\ncahcesuolo.no\n\u010D\xE1hcesuolo.no\ndavvenjarga.no\ndavvenj\xE1rga.no\ndavvesiida.no\ndeatnu.no\ndielddanuorri.no\ndivtasvuodna.no\ndivttasvuotna.no\ndonna.no\nd\xF8nna.no\ndovre.no\ndrammen.no\ndrangedal.no\ndyroy.no\ndyr\xF8y.no\neid.no\neidfjord.no\neidsberg.no\neidskog.no\neidsvoll.no\neigersund.no\nelverum.no\nenebakk.no\nengerdal.no\netne.no\netnedal.no\nevenassi.no\neven\xE1\u0161\u0161i.no\nevenes.no\nevje-og-hornnes.no\nfarsund.no\nfauske.no\nfedje.no\nfet.no\nfinnoy.no\nfinn\xF8y.no\nfitjar.no\nfjaler.no\nfjell.no\nfla.no\nfl\xE5.no\nflakstad.no\nflatanger.no\nflekkefjord.no\nflesberg.no\nflora.no\nfolldal.no\nforde.no\nf\xF8rde.no\nforsand.no\nfosnes.no\nfr\xE6na.no\nfrana.no\nfrei.no\nfrogn.no\nfroland.no\nfrosta.no\nfroya.no\nfr\xF8ya.no\nfuoisku.no\nfuossko.no\nfusa.no\nfyresdal.no\ngaivuotna.no\ng\xE1ivuotna.no\ngalsa.no\ng\xE1ls\xE1.no\ngamvik.no\ngangaviika.no\ng\xE1\u014Bgaviika.no\ngaular.no\ngausdal.no\ngiehtavuoatna.no\ngildeskal.no\ngildesk\xE5l.no\ngiske.no\ngjemnes.no\ngjerdrum.no\ngjerstad.no\ngjesdal.no\ngjovik.no\ngj\xF8vik.no\ngloppen.no\ngol.no\ngran.no\ngrane.no\ngranvin.no\ngratangen.no\ngrimstad.no\ngrong.no\ngrue.no\ngulen.no\nguovdageaidnu.no\nha.no\nh\xE5.no\nhabmer.no\nh\xE1bmer.no\nhadsel.no\nh\xE6gebostad.no\nhagebostad.no\nhalden.no\nhalsa.no\nhamar.no\nhamaroy.no\nhammarfeasta.no\nh\xE1mm\xE1rfeasta.no\nhammerfest.no\nhapmir.no\nh\xE1pmir.no\nharam.no\nhareid.no\nharstad.no\nhasvik.no\nhattfjelldal.no\nhaugesund.no\nos.hedmark.no\nvaler.hedmark.no\nv\xE5ler.hedmark.no\nhemne.no\nhemnes.no\nhemsedal.no\nhitra.no\nhjartdal.no\nhjelmeland.no\nhobol.no\nhob\xF8l.no\nhof.no\nhol.no\nhole.no\nholmestrand.no\nholtalen.no\nholt\xE5len.no\nos.hordaland.no\nhornindal.no\nhorten.no\nhoyanger.no\nh\xF8yanger.no\nhoylandet.no\nh\xF8ylandet.no\nhurdal.no\nhurum.no\nhvaler.no\nhyllestad.no\nibestad.no\ninderoy.no\ninder\xF8y.no\niveland.no\nivgu.no\njevnaker.no\njolster.no\nj\xF8lster.no\njondal.no\nkafjord.no\nk\xE5fjord.no\nkarasjohka.no\nk\xE1r\xE1\u0161johka.no\nkarasjok.no\nkarlsoy.no\nkarmoy.no\nkarm\xF8y.no\nkautokeino.no\nklabu.no\nkl\xE6bu.no\nklepp.no\nkongsberg.no\nkongsvinger.no\nkraanghke.no\nkr\xE5anghke.no\nkragero.no\nkrager\xF8.no\nkristiansand.no\nkristiansund.no\nkrodsherad.no\nkr\xF8dsherad.no\nkv\xE6fjord.no\nkv\xE6nangen.no\nkvafjord.no\nkvalsund.no\nkvam.no\nkvanangen.no\nkvinesdal.no\nkvinnherad.no\nkviteseid.no\nkvitsoy.no\nkvits\xF8y.no\nlaakesvuemie.no\nl\xE6rdal.no\nlahppi.no\nl\xE1hppi.no\nlardal.no\nlarvik.no\nlavagis.no\nlavangen.no\nleangaviika.no\nlea\u014Bgaviika.no\nlebesby.no\nleikanger.no\nleirfjord.no\nleka.no\nleksvik.no\nlenvik.no\nlerdal.no\nlesja.no\nlevanger.no\nlier.no\nlierne.no\nlillehammer.no\nlillesand.no\nlindas.no\nlind\xE5s.no\nlindesnes.no\nloabat.no\nloab\xE1t.no\nlodingen.no\nl\xF8dingen.no\nlom.no\nloppa.no\nlorenskog.no\nl\xF8renskog.no\nloten.no\nl\xF8ten.no\nlund.no\nlunner.no\nluroy.no\nlur\xF8y.no\nluster.no\nlyngdal.no\nlyngen.no\nmalatvuopmi.no\nm\xE1latvuopmi.no\nmalselv.no\nm\xE5lselv.no\nmalvik.no\nmandal.no\nmarker.no\nmarnardal.no\nmasfjorden.no\nmasoy.no\nm\xE5s\xF8y.no\nmatta-varjjat.no\nm\xE1tta-v\xE1rjjat.no\nmeland.no\nmeldal.no\nmelhus.no\nmeloy.no\nmel\xF8y.no\nmeraker.no\nmer\xE5ker.no\nmidsund.no\nmidtre-gauldal.no\nmoareke.no\nmo\xE5reke.no\nmodalen.no\nmodum.no\nmolde.no\nheroy.more-og-romsdal.no\nsande.more-og-romsdal.no\nher\xF8y.m\xF8re-og-romsdal.no\nsande.m\xF8re-og-romsdal.no\nmoskenes.no\nmoss.no\nmuosat.no\nmuos\xE1t.no\nnaamesjevuemie.no\nn\xE5\xE5mesjevuemie.no\nn\xE6r\xF8y.no\nnamdalseid.no\nnamsos.no\nnamsskogan.no\nnannestad.no\nnaroy.no\nnarviika.no\nnarvik.no\nnaustdal.no\nnavuotna.no\nn\xE1vuotna.no\nnedre-eiker.no\nnesna.no\nnesodden.no\nnesseby.no\nnesset.no\nnissedal.no\nnittedal.no\nnord-aurdal.no\nnord-fron.no\nnord-odal.no\nnorddal.no\nnordkapp.no\nbo.nordland.no\nb\xF8.nordland.no\nheroy.nordland.no\nher\xF8y.nordland.no\nnordre-land.no\nnordreisa.no\nnore-og-uvdal.no\nnotodden.no\nnotteroy.no\nn\xF8tter\xF8y.no\nodda.no\noksnes.no\n\xF8ksnes.no\nomasvuotna.no\noppdal.no\noppegard.no\noppeg\xE5rd.no\norkdal.no\norland.no\n\xF8rland.no\norskog.no\n\xF8rskog.no\norsta.no\n\xF8rsta.no\nosen.no\nosteroy.no\noster\xF8y.no\nvaler.ostfold.no\nv\xE5ler.\xF8stfold.no\nostre-toten.no\n\xF8stre-toten.no\noverhalla.no\novre-eiker.no\n\xF8vre-eiker.no\noyer.no\n\xF8yer.no\noygarden.no\n\xF8ygarden.no\noystre-slidre.no\n\xF8ystre-slidre.no\nporsanger.no\nporsangu.no\npors\xE1\u014Bgu.no\nporsgrunn.no\nrade.no\nr\xE5de.no\nradoy.no\nrad\xF8y.no\nr\xE6lingen.no\nrahkkeravju.no\nr\xE1hkker\xE1vju.no\nraisa.no\nr\xE1isa.no\nrakkestad.no\nralingen.no\nrana.no\nrandaberg.no\nrauma.no\nrendalen.no\nrennebu.no\nrennesoy.no\nrennes\xF8y.no\nrindal.no\nringebu.no\nringerike.no\nringsaker.no\nrisor.no\nris\xF8r.no\nrissa.no\nroan.no\nrodoy.no\nr\xF8d\xF8y.no\nrollag.no\nromsa.no\nromskog.no\nr\xF8mskog.no\nroros.no\nr\xF8ros.no\nrost.no\nr\xF8st.no\nroyken.no\nr\xF8yken.no\nroyrvik.no\nr\xF8yrvik.no\nruovat.no\nrygge.no\nsalangen.no\nsalat.no\ns\xE1lat.no\ns\xE1l\xE1t.no\nsaltdal.no\nsamnanger.no\nsandefjord.no\nsandnes.no\nsandoy.no\nsand\xF8y.no\nsarpsborg.no\nsauda.no\nsauherad.no\nsel.no\nselbu.no\nselje.no\nseljord.no\nsiellak.no\nsigdal.no\nsiljan.no\nsirdal.no\nskanit.no\nsk\xE1nit.no\nskanland.no\nsk\xE5nland.no\nskaun.no\nskedsmo.no\nski.no\nskien.no\nskierva.no\nskierv\xE1.no\nskiptvet.no\nskjak.no\nskj\xE5k.no\nskjervoy.no\nskjerv\xF8y.no\nskodje.no\nsmola.no\nsm\xF8la.no\nsnaase.no\nsn\xE5ase.no\nsnasa.no\nsn\xE5sa.no\nsnillfjord.no\nsnoasa.no\nsogndal.no\nsogne.no\ns\xF8gne.no\nsokndal.no\nsola.no\nsolund.no\nsomna.no\ns\xF8mna.no\nsondre-land.no\ns\xF8ndre-land.no\nsongdalen.no\nsor-aurdal.no\ns\xF8r-aurdal.no\nsor-fron.no\ns\xF8r-fron.no\nsor-odal.no\ns\xF8r-odal.no\nsor-varanger.no\ns\xF8r-varanger.no\nsorfold.no\ns\xF8rfold.no\nsorreisa.no\ns\xF8rreisa.no\nsortland.no\nsorum.no\ns\xF8rum.no\nspydeberg.no\nstange.no\nstavanger.no\nsteigen.no\nsteinkjer.no\nstjordal.no\nstj\xF8rdal.no\nstokke.no\nstor-elvdal.no\nstord.no\nstordal.no\nstorfjord.no\nstrand.no\nstranda.no\nstryn.no\nsula.no\nsuldal.no\nsund.no\nsunndal.no\nsurnadal.no\nsveio.no\nsvelvik.no\nsykkylven.no\ntana.no\nbo.telemark.no\nb\xF8.telemark.no\ntime.no\ntingvoll.no\ntinn.no\ntjeldsund.no\ntjome.no\ntj\xF8me.no\ntokke.no\ntolga.no\ntonsberg.no\nt\xF8nsberg.no\ntorsken.no\ntr\xE6na.no\ntrana.no\ntranoy.no\ntran\xF8y.no\ntroandin.no\ntrogstad.no\ntr\xF8gstad.no\ntromsa.no\ntromso.no\ntroms\xF8.no\ntrondheim.no\ntrysil.no\ntvedestrand.no\ntydal.no\ntynset.no\ntysfjord.no\ntysnes.no\ntysv\xE6r.no\ntysvar.no\nullensaker.no\nullensvang.no\nulvik.no\nunjarga.no\nunj\xE1rga.no\nutsira.no\nvaapste.no\nvadso.no\nvads\xF8.no\nv\xE6r\xF8y.no\nvaga.no\nv\xE5g\xE5.no\nvagan.no\nv\xE5gan.no\nvagsoy.no\nv\xE5gs\xF8y.no\nvaksdal.no\nvalle.no\nvang.no\nvanylven.no\nvardo.no\nvard\xF8.no\nvarggat.no\nv\xE1rgg\xE1t.no\nvaroy.no\nvefsn.no\nvega.no\nvegarshei.no\nveg\xE5rshei.no\nvennesla.no\nverdal.no\nverran.no\nvestby.no\nsande.vestfold.no\nvestnes.no\nvestre-slidre.no\nvestre-toten.no\nvestvagoy.no\nvestv\xE5g\xF8y.no\nvevelstad.no\nvik.no\nvikna.no\nvindafjord.no\nvoagat.no\nvolda.no\nvoss.no\n\n//
+        np : http://www.mos.com.np/register.html\n*.np\n\n// nr : http://cenpac.net.nr/dns/index.html\n//
+        Submitted by registry <technician@cenpac.net.nr>\nnr\nbiz.nr\ncom.nr\nedu.nr\ngov.nr\ninfo.nr\nnet.nr\norg.nr\n\n//
+        nu : https://www.iana.org/domains/root/db/nu.html\nnu\n\n// nz : https://www.iana.org/domains/root/db/nz.html\n//
+        Submitted by registry <jay@nzrs.net.nz>\nnz\nac.nz\nco.nz\ncri.nz\ngeek.nz\ngen.nz\ngovt.nz\nhealth.nz\niwi.nz\nkiwi.nz\nmaori.nz\nm\u0101ori.nz\nmil.nz\nnet.nz\norg.nz\nparliament.nz\nschool.nz\n\n//
+        om : https://www.iana.org/domains/root/db/om.html\nom\nco.om\ncom.om\nedu.om\ngov.om\nmed.om\nmuseum.om\nnet.om\norg.om\npro.om\n\n//
+        onion : https://tools.ietf.org/html/rfc7686\nonion\n\n// org : https://www.iana.org/domains/root/db/org.html\norg\n\n//
+        pa : http://www.nic.pa/\n// Some additional second level \"domains\" resolve
+        directly as hostnames, such as\n// pannet.pa, so we add a rule for \"pa\".\npa\nabo.pa\nac.pa\ncom.pa\nedu.pa\ngob.pa\ning.pa\nmed.pa\nnet.pa\nnom.pa\norg.pa\nsld.pa\n\n//
+        pe : https://www.nic.pe/InformeFinalComision.pdf\npe\ncom.pe\nedu.pe\ngob.pe\nmil.pe\nnet.pe\nnom.pe\norg.pe\n\n//
+        pf : http://www.gobin.info/domainname/formulaire-pf.pdf\npf\ncom.pf\nedu.pf\norg.pf\n\n//
+        pg : https://www.iana.org/domains/root/db/pg.html\n*.pg\n\n// ph : https://www.iana.org/domains/root/db/ph.html\n//
+        Submitted by registry <jed@email.com.ph>\nph\ncom.ph\nedu.ph\ngov.ph\ni.ph\nmil.ph\nnet.ph\nngo.ph\norg.ph\n\n//
+        pk : https://pk5.pknic.net.pk/pk5/msgNamepk.PK\n// Contact Email: staff@pknic.net.pk\npk\nac.pk\nbiz.pk\ncom.pk\nedu.pk\nfam.pk\ngkp.pk\ngob.pk\ngog.pk\ngok.pk\ngop.pk\ngos.pk\ngov.pk\nnet.pk\norg.pk\nweb.pk\n\n//
+        pl : https://www.dns.pl/en/\n// Confirmed by registry <info@dns.pl> 2024-11-18\npl\ncom.pl\nnet.pl\norg.pl\n//
+        pl functional domains : https://www.dns.pl/en/list_of_functional_domain_names\nagro.pl\naid.pl\natm.pl\nauto.pl\nbiz.pl\nedu.pl\ngmina.pl\ngsm.pl\ninfo.pl\nmail.pl\nmedia.pl\nmiasta.pl\nmil.pl\nnieruchomosci.pl\nnom.pl\npc.pl\npowiat.pl\npriv.pl\nrealestate.pl\nrel.pl\nsex.pl\nshop.pl\nsklep.pl\nsos.pl\nszkola.pl\ntargi.pl\ntm.pl\ntourism.pl\ntravel.pl\nturystyka.pl\n//
+        Government domains : https://www.dns.pl/informacje_o_rejestracji_domen_gov_pl\n//
+        In accordance with the .gov.pl Domain Name Regulations : https://www.dns.pl/regulamin_gov_pl\ngov.pl\nap.gov.pl\ngriw.gov.pl\nic.gov.pl\nis.gov.pl\nkmpsp.gov.pl\nkonsulat.gov.pl\nkppsp.gov.pl\nkwp.gov.pl\nkwpsp.gov.pl\nmup.gov.pl\nmw.gov.pl\noia.gov.pl\noirm.gov.pl\noke.gov.pl\noow.gov.pl\noschr.gov.pl\noum.gov.pl\npa.gov.pl\npinb.gov.pl\npiw.gov.pl\npo.gov.pl\npr.gov.pl\npsp.gov.pl\npsse.gov.pl\npup.gov.pl\nrzgw.gov.pl\nsa.gov.pl\nsdn.gov.pl\nsko.gov.pl\nso.gov.pl\nsr.gov.pl\nstarostwo.gov.pl\nug.gov.pl\nugim.gov.pl\num.gov.pl\numig.gov.pl\nupow.gov.pl\nuppo.gov.pl\nus.gov.pl\nuw.gov.pl\nuzs.gov.pl\nwif.gov.pl\nwiih.gov.pl\nwinb.gov.pl\nwios.gov.pl\nwitd.gov.pl\nwiw.gov.pl\nwkz.gov.pl\nwsa.gov.pl\nwskr.gov.pl\nwsse.gov.pl\nwuoz.gov.pl\nwzmiuw.gov.pl\nzp.gov.pl\nzpisdn.gov.pl\n//
+        pl regional domains : https://www.dns.pl/en/list_of_regional_domain_names\naugustow.pl\nbabia-gora.pl\nbedzin.pl\nbeskidy.pl\nbialowieza.pl\nbialystok.pl\nbielawa.pl\nbieszczady.pl\nboleslawiec.pl\nbydgoszcz.pl\nbytom.pl\ncieszyn.pl\nczeladz.pl\nczest.pl\ndlugoleka.pl\nelblag.pl\nelk.pl\nglogow.pl\ngniezno.pl\ngorlice.pl\ngrajewo.pl\nilawa.pl\njaworzno.pl\njelenia-gora.pl\njgora.pl\nkalisz.pl\nkarpacz.pl\nkartuzy.pl\nkaszuby.pl\nkatowice.pl\nkazimierz-dolny.pl\nkepno.pl\nketrzyn.pl\nklodzko.pl\nkobierzyce.pl\nkolobrzeg.pl\nkonin.pl\nkonskowola.pl\nkutno.pl\nlapy.pl\nlebork.pl\nlegnica.pl\nlezajsk.pl\nlimanowa.pl\nlomza.pl\nlowicz.pl\nlubin.pl\nlukow.pl\nmalbork.pl\nmalopolska.pl\nmazowsze.pl\nmazury.pl\nmielec.pl\nmielno.pl\nmragowo.pl\nnaklo.pl\nnowaruda.pl\nnysa.pl\nolawa.pl\nolecko.pl\nolkusz.pl\nolsztyn.pl\nopoczno.pl\nopole.pl\nostroda.pl\nostroleka.pl\nostrowiec.pl\nostrowwlkp.pl\npila.pl\npisz.pl\npodhale.pl\npodlasie.pl\npolkowice.pl\npomorskie.pl\npomorze.pl\nprochowice.pl\npruszkow.pl\nprzeworsk.pl\npulawy.pl\nradom.pl\nrawa-maz.pl\nrybnik.pl\nrzeszow.pl\nsanok.pl\nsejny.pl\nskoczow.pl\nslask.pl\nslupsk.pl\nsosnowiec.pl\nstalowa-wola.pl\nstarachowice.pl\nstargard.pl\nsuwalki.pl\nswidnica.pl\nswiebodzin.pl\nswinoujscie.pl\nszczecin.pl\nszczytno.pl\ntarnobrzeg.pl\ntgory.pl\nturek.pl\ntychy.pl\nustka.pl\nwalbrzych.pl\nwarmia.pl\nwarszawa.pl\nwaw.pl\nwegrow.pl\nwielun.pl\nwlocl.pl\nwloclawek.pl\nwodzislaw.pl\nwolomin.pl\nwroclaw.pl\nzachpomor.pl\nzagan.pl\nzarow.pl\nzgora.pl\nzgorzelec.pl\n\n//
+        pm : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\npm\n\n//
+        pn : https://www.iana.org/domains/root/db/pn.html\npn\nco.pn\nedu.pn\ngov.pn\nnet.pn\norg.pn\n\n//
+        post : https://www.iana.org/domains/root/db/post.html\npost\n\n// pr : http://www.nic.pr/index.asp?f=1\npr\nbiz.pr\ncom.pr\nedu.pr\ngov.pr\ninfo.pr\nisla.pr\nname.pr\nnet.pr\norg.pr\npro.pr\n//
+        these aren't mentioned on nic.pr, but on https://www.iana.org/domains/root/db/pr.html\nac.pr\nest.pr\nprof.pr\n\n//
+        pro : http://registry.pro/get-pro\npro\naaa.pro\naca.pro\nacct.pro\navocat.pro\nbar.pro\ncpa.pro\neng.pro\njur.pro\nlaw.pro\nmed.pro\nrecht.pro\n\n//
+        ps : https://www.iana.org/domains/root/db/ps.html\n// http://www.nic.ps/registration/policy.html#reg\nps\ncom.ps\nedu.ps\ngov.ps\nnet.ps\norg.ps\nplo.ps\nsec.ps\n\n//
+        pt : https://www.dns.pt/en/domain/pt-terms-and-conditions-registration-rules/\npt\ncom.pt\nedu.pt\ngov.pt\nint.pt\nnet.pt\nnome.pt\norg.pt\npubl.pt\n\n//
+        pw : https://www.iana.org/domains/root/db/pw.html\n// Confirmed by registry
+        in private correspondence with @dnsguru 2024-12-09\npw\ngov.pw\n\n// py :
+        https://www.iana.org/domains/root/db/py.html\n// Submitted by registry\npy\ncom.py\ncoop.py\nedu.py\ngov.py\nmil.py\nnet.py\norg.py\n\n//
+        qa : http://domains.qa/en/\nqa\ncom.qa\nedu.qa\ngov.qa\nmil.qa\nname.qa\nnet.qa\norg.qa\nsch.qa\n\n//
+        re : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\n//
+        Confirmed by registry <support@afnic.fr> 2024-11-18\nre\n// Closed for registration
+        on 2013-03-15 but domains are still maintained\nasso.re\ncom.re\n\n// ro :
+        http://www.rotld.ro/\nro\narts.ro\ncom.ro\nfirm.ro\ninfo.ro\nnom.ro\nnt.ro\norg.ro\nrec.ro\nstore.ro\ntm.ro\nwww.ro\n\n//
+        rs : https://www.rnids.rs/en/domains/national-domains\nrs\nac.rs\nco.rs\nedu.rs\ngov.rs\nin.rs\norg.rs\n\n//
+        ru : https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf\n// Submitted by George
+        Georgievsky <gug@cctld.ru>\nru\n\n// rw : https://www.iana.org/domains/root/db/rw.html\nrw\nac.rw\nco.rw\ncoop.rw\ngov.rw\nmil.rw\nnet.rw\norg.rw\n\n//
+        sa : http://www.nic.net.sa/\nsa\ncom.sa\nedu.sa\ngov.sa\nmed.sa\nnet.sa\norg.sa\npub.sa\nsch.sa\n\n//
+        sb : http://www.sbnic.net.sb/\n// Submitted by registry <lee.humphries@telekom.com.sb>\nsb\ncom.sb\nedu.sb\ngov.sb\nnet.sb\norg.sb\n\n//
+        sc : http://www.nic.sc/\nsc\ncom.sc\nedu.sc\ngov.sc\nnet.sc\norg.sc\n\n//
+        sd : https://www.iana.org/domains/root/db/sd.html\n// Submitted by registry
+        <admin@isoc.sd>\nsd\ncom.sd\nedu.sd\ngov.sd\ninfo.sd\nmed.sd\nnet.sd\norg.sd\ntv.sd\n\n//
+        se : https://www.iana.org/domains/root/db/se.html\n// https://data.internetstiftelsen.se/barred_domains_list.txt
+        -> Second level domains & Sub-domains\n// Confirmed by Registry Services <registry@internetstiftelsen.se>
+        2024-11-20\nse\na.se\nac.se\nb.se\nbd.se\nbrand.se\nc.se\nd.se\ne.se\nf.se\nfh.se\nfhsk.se\nfhv.se\ng.se\nh.se\ni.se\nk.se\nkomforb.se\nkommunalforbund.se\nkomvux.se\nl.se\nlanbib.se\nm.se\nn.se\nnaturbruksgymn.se\no.se\norg.se\np.se\nparti.se\npp.se\npress.se\nr.se\ns.se\nt.se\ntm.se\nu.se\nw.se\nx.se\ny.se\nz.se\n\n//
+        sg : https://www.sgnic.sg/domain-registration/sg-categories-rules\n// Confirmed
+        by registry <dnq@sgnic.sg> 2024-11-19\nsg\ncom.sg\nedu.sg\ngov.sg\nnet.sg\norg.sg\n\n//
+        sh : http://nic.sh/rules.htm\nsh\ncom.sh\ngov.sh\nmil.sh\nnet.sh\norg.sh\n\n//
+        si : https://www.iana.org/domains/root/db/si.html\nsi\n\n// sj : No registrations
+        at this time.\n// Submitted by registry <jarle@uninett.no>\nsj\n\n// sk :
+        https://www.iana.org/domains/root/db/sk.html\n// https://sk-nic.sk/\nsk\norg.sk\n\n//
+        sl : http://www.nic.sl\n// Submitted by registry <adam@neoip.com>\nsl\ncom.sl\nedu.sl\ngov.sl\nnet.sl\norg.sl\n\n//
+        sm : https://www.iana.org/domains/root/db/sm.html\nsm\n\n// sn : https://www.iana.org/domains/root/db/sn.html\nsn\nart.sn\ncom.sn\nedu.sn\ngouv.sn\norg.sn\nuniv.sn\n\n//
+        so : http://sonic.so/policies/\nso\ncom.so\nedu.so\ngov.so\nme.so\nnet.so\norg.so\n\n//
+        sr : https://www.iana.org/domains/root/db/sr.html\nsr\n\n// ss : https://registry.nic.ss/\n//
+        Submitted by registry <technical@nic.ss>\nss\nbiz.ss\nco.ss\ncom.ss\nedu.ss\ngov.ss\nme.ss\nnet.ss\norg.ss\nsch.ss\n\n//
+        st : http://www.nic.st/html/policyrules/\nst\nco.st\ncom.st\nconsulado.st\nedu.st\nembaixada.st\nmil.st\nnet.st\norg.st\nprincipe.st\nsaotome.st\nstore.st\n\n//
+        su : https://www.iana.org/domains/root/db/su.html\nsu\n\n// sv : https://www.iana.org/domains/root/db/sv.html\nsv\ncom.sv\nedu.sv\ngob.sv\norg.sv\nred.sv\n\n//
+        sx : https://www.iana.org/domains/root/db/sx.html\n// Submitted by registry
+        <jcvignes@openregistry.com>\nsx\ngov.sx\n\n// sy : https://www.iana.org/domains/root/db/sy.html\nsy\ncom.sy\nedu.sy\ngov.sy\nmil.sy\nnet.sy\norg.sy\n\n//
+        sz : https://www.iana.org/domains/root/db/sz.html\n// http://www.sispa.org.sz/\nsz\nac.sz\nco.sz\norg.sz\n\n//
+        tc : https://www.iana.org/domains/root/db/tc.html\ntc\n\n// td : https://www.iana.org/domains/root/db/td.html\ntd\n\n//
+        tel : https://www.iana.org/domains/root/db/tel.html\n// http://www.telnic.org/\ntel\n\n//
+        tf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\ntf\n\n//
+        tg : https://www.iana.org/domains/root/db/tg.html\n// http://www.nic.tg/\ntg\n\n//
+        th : https://www.iana.org/domains/root/db/th.html\n// Submitted by registry
+        <krit@thains.co.th>\nth\nac.th\nco.th\ngo.th\nin.th\nmi.th\nnet.th\nor.th\n\n//
+        tj : http://www.nic.tj/policy.html\ntj\nac.tj\nbiz.tj\nco.tj\ncom.tj\nedu.tj\ngo.tj\ngov.tj\nint.tj\nmil.tj\nname.tj\nnet.tj\nnic.tj\norg.tj\ntest.tj\nweb.tj\n\n//
+        tk : https://www.iana.org/domains/root/db/tk.html\ntk\n\n// tl : https://www.iana.org/domains/root/db/tl.html\ntl\ngov.tl\n\n//
+        tm : https://www.nic.tm/local.html\n// Confirmed by registry <admin@nic.TM>
+        2024-11-19\ntm\nco.tm\ncom.tm\nedu.tm\ngov.tm\nmil.tm\nnet.tm\nnom.tm\norg.tm\n\n//
+        tn : http://www.registre.tn/fr/\n// https://whois.ati.tn/\ntn\ncom.tn\nens.tn\nfin.tn\ngov.tn\nind.tn\ninfo.tn\nintl.tn\nmincom.tn\nnat.tn\nnet.tn\norg.tn\nperso.tn\ntourism.tn\n\n//
+        to : https://www.iana.org/domains/root/db/to.html\n// Submitted by registry
+        <egullich@colo.to>\nto\ncom.to\nedu.to\ngov.to\nmil.to\nnet.to\norg.to\n\n//
+        tr : https://nic.tr/\n// https://nic.tr/forms/eng/policies.pdf\n// https://nic.tr/index.php?USRACTN=PRICELST\ntr\nav.tr\nbbs.tr\nbel.tr\nbiz.tr\ncom.tr\ndr.tr\nedu.tr\ngen.tr\ngov.tr\ninfo.tr\nk12.tr\nkep.tr\nmil.tr\nname.tr\nnet.tr\norg.tr\npol.tr\ntel.tr\ntsk.tr\ntv.tr\nweb.tr\n//
+        Used by Northern Cyprus\nnc.tr\n// Used by government agencies of Northern
+        Cyprus\ngov.nc.tr\n\n// tt : https://www.nic.tt/\n// Confirmed by registry
+        <admin@nic.tt> 2024-11-19\ntt\nbiz.tt\nco.tt\ncom.tt\nedu.tt\ngov.tt\ninfo.tt\nmil.tt\nname.tt\nnet.tt\norg.tt\npro.tt\n\n//
+        tv : https://www.iana.org/domains/root/db/tv.html\n// Not listing any 2LDs
+        as reserved since none seem to exist in practice,\n// Wikipedia notwithstanding.\ntv\n\n//
+        tw : https://www.iana.org/domains/root/db/tw.html\n// https://twnic.tw/dnservice_catag.php\n//
+        Confirmed by registry <dns@twnic.tw> 2024-11-26\ntw\nclub.tw\ncom.tw\nebiz.tw\nedu.tw\ngame.tw\ngov.tw\nidv.tw\nmil.tw\nnet.tw\norg.tw\n\n//
+        tz : http://www.tznic.or.tz/index.php/domains\n// Submitted by registry <manager@tznic.or.tz>\ntz\nac.tz\nco.tz\ngo.tz\nhotel.tz\ninfo.tz\nme.tz\nmil.tz\nmobi.tz\nne.tz\nor.tz\nsc.tz\ntv.tz\n\n//
+        ua : https://hostmaster.ua/policy/?ua\n// Submitted by registry <dk@cctld.ua>\nua\n//
+        ua 2LD\ncom.ua\nedu.ua\ngov.ua\nin.ua\nnet.ua\norg.ua\n// ua geographic names\n//
+        https://hostmaster.ua/2ld/\ncherkassy.ua\ncherkasy.ua\nchernigov.ua\nchernihiv.ua\nchernivtsi.ua\nchernovtsy.ua\nck.ua\ncn.ua\ncr.ua\ncrimea.ua\ncv.ua\ndn.ua\ndnepropetrovsk.ua\ndnipropetrovsk.ua\ndonetsk.ua\ndp.ua\nif.ua\nivano-frankivsk.ua\nkh.ua\nkharkiv.ua\nkharkov.ua\nkherson.ua\nkhmelnitskiy.ua\nkhmelnytskyi.ua\nkiev.ua\nkirovograd.ua\nkm.ua\nkr.ua\nkropyvnytskyi.ua\nkrym.ua\nks.ua\nkv.ua\nkyiv.ua\nlg.ua\nlt.ua\nlugansk.ua\nluhansk.ua\nlutsk.ua\nlv.ua\nlviv.ua\nmk.ua\nmykolaiv.ua\nnikolaev.ua\nod.ua\nodesa.ua\nodessa.ua\npl.ua\npoltava.ua\nrivne.ua\nrovno.ua\nrv.ua\nsb.ua\nsebastopol.ua\nsevastopol.ua\nsm.ua\nsumy.ua\nte.ua\nternopil.ua\nuz.ua\nuzhgorod.ua\nuzhhorod.ua\nvinnica.ua\nvinnytsia.ua\nvn.ua\nvolyn.ua\nyalta.ua\nzakarpattia.ua\nzaporizhzhe.ua\nzaporizhzhia.ua\nzhitomir.ua\nzhytomyr.ua\nzp.ua\nzt.ua\n\n//
+        ug : https://www.registry.co.ug/\n// https://www.registry.co.ug, https://whois.co.ug\n//
+        Confirmed by registry <support@i3c.co.ug> 2025-01-20\nug\nac.ug\nco.ug\ncom.ug\nedu.ug\ngo.ug\ngov.ug\nmil.ug\nne.ug\nor.ug\norg.ug\nsc.ug\nus.ug\n\n//
+        uk : https://www.iana.org/domains/root/db/uk.html\n// Submitted by registry
+        <Michael.Daly@nominet.org.uk>\nuk\nac.uk\nco.uk\ngov.uk\nltd.uk\nme.uk\nnet.uk\nnhs.uk\norg.uk\nplc.uk\npolice.uk\n*.sch.uk\n\n//
+        us : https://www.iana.org/domains/root/db/us.html\n// Confirmed via the .us
+        zone file by William Harrison 2024-12-10\nus\ndni.us\nisa.us\nnsn.us\n// Geographic
+        Names\nak.us\nal.us\nar.us\nas.us\naz.us\nca.us\nco.us\nct.us\ndc.us\nde.us\nfl.us\nga.us\ngu.us\nhi.us\nia.us\nid.us\nil.us\nin.us\nks.us\nky.us\nla.us\nma.us\nmd.us\nme.us\nmi.us\nmn.us\nmo.us\nms.us\nmt.us\nnc.us\nnd.us\nne.us\nnh.us\nnj.us\nnm.us\nnv.us\nny.us\noh.us\nok.us\nor.us\npa.us\npr.us\nri.us\nsc.us\nsd.us\ntn.us\ntx.us\nut.us\nva.us\nvi.us\nvt.us\nwa.us\nwi.us\nwv.us\nwy.us\n//
+        The registrar notes several more specific domains available in each state,\n//
+        such as state.*.us, dst.*.us, etc., but resolution of these is somewhat\n//
+        haphazard; in some states these domains resolve as addresses, while in others\n//
+        only subdomains are available, or even nothing at all. We include the\n//
+        most common ones where it's clear that different sites are different\n// entities.\nk12.ak.us\nk12.al.us\nk12.ar.us\nk12.as.us\nk12.az.us\nk12.ca.us\nk12.co.us\nk12.ct.us\nk12.dc.us\nk12.fl.us\nk12.ga.us\nk12.gu.us\n//
+        k12.hi.us - Bug 614565 - Hawaii has a state-wide DOE login\nk12.ia.us\nk12.id.us\nk12.il.us\nk12.in.us\nk12.ks.us\nk12.ky.us\nk12.la.us\nk12.ma.us\nk12.md.us\nk12.me.us\nk12.mi.us\nk12.mn.us\nk12.mo.us\nk12.ms.us\nk12.mt.us\nk12.nc.us\n//
+        k12.nd.us - Bug 1028347 - Removed at request of Travis Rosso <trossow@nd.gov>\nk12.ne.us\nk12.nh.us\nk12.nj.us\nk12.nm.us\nk12.nv.us\nk12.ny.us\nk12.oh.us\nk12.ok.us\nk12.or.us\nk12.pa.us\nk12.pr.us\n//
+        k12.ri.us - Removed at request of Kim Cournoyer <netsupport@staff.ri.net>\nk12.sc.us\n//
+        k12.sd.us - Bug 934131 - Removed at request of James Booze <James.Booze@k12.sd.us>\nk12.tn.us\nk12.tx.us\nk12.ut.us\nk12.va.us\nk12.vi.us\nk12.vt.us\nk12.wa.us\nk12.wi.us\n//
+        k12.wv.us - Bug 947705 - Removed at request of Verne Britton <verne@wvnet.edu>\ncc.ak.us\nlib.ak.us\ncc.al.us\nlib.al.us\ncc.ar.us\nlib.ar.us\ncc.as.us\nlib.as.us\ncc.az.us\nlib.az.us\ncc.ca.us\nlib.ca.us\ncc.co.us\nlib.co.us\ncc.ct.us\nlib.ct.us\ncc.dc.us\nlib.dc.us\ncc.de.us\ncc.fl.us\nlib.fl.us\ncc.ga.us\nlib.ga.us\ncc.gu.us\nlib.gu.us\ncc.hi.us\nlib.hi.us\ncc.ia.us\nlib.ia.us\ncc.id.us\nlib.id.us\ncc.il.us\nlib.il.us\ncc.in.us\nlib.in.us\ncc.ks.us\nlib.ks.us\ncc.ky.us\nlib.ky.us\ncc.la.us\nlib.la.us\ncc.ma.us\nlib.ma.us\ncc.md.us\nlib.md.us\ncc.me.us\nlib.me.us\ncc.mi.us\nlib.mi.us\ncc.mn.us\nlib.mn.us\ncc.mo.us\nlib.mo.us\ncc.ms.us\ncc.mt.us\nlib.mt.us\ncc.nc.us\nlib.nc.us\ncc.nd.us\nlib.nd.us\ncc.ne.us\nlib.ne.us\ncc.nh.us\nlib.nh.us\ncc.nj.us\nlib.nj.us\ncc.nm.us\nlib.nm.us\ncc.nv.us\nlib.nv.us\ncc.ny.us\nlib.ny.us\ncc.oh.us\nlib.oh.us\ncc.ok.us\nlib.ok.us\ncc.or.us\nlib.or.us\ncc.pa.us\nlib.pa.us\ncc.pr.us\nlib.pr.us\ncc.ri.us\nlib.ri.us\ncc.sc.us\nlib.sc.us\ncc.sd.us\nlib.sd.us\ncc.tn.us\nlib.tn.us\ncc.tx.us\nlib.tx.us\ncc.ut.us\nlib.ut.us\ncc.va.us\nlib.va.us\ncc.vi.us\nlib.vi.us\ncc.vt.us\nlib.vt.us\ncc.wa.us\nlib.wa.us\ncc.wi.us\nlib.wi.us\ncc.wv.us\ncc.wy.us\nk12.wy.us\n//
+        lib.wv.us - Bug 941670 - Removed at request of Larry W Arnold <arnold@wvlc.lib.wv.us>\nlib.wy.us\n//
+        k12.ma.us contains school districts in Massachusetts. The 4LDs are\n// managed
+        independently except for private (PVT), charter (CHTR) and\n// parochial (PAROCH)
+        schools. Those are delegated directly to the\n// 5LD operators. <k12-ma-hostmaster@rsuc.gweep.net>\nchtr.k12.ma.us\nparoch.k12.ma.us\npvt.k12.ma.us\n//
+        Merit Network, Inc. maintains the registry for =~ /(k12|cc|lib).mi.us/ and
+        the following\n// see also: https://domreg.merit.edu : domreg@merit.edu\n//
+        see also: whois -h whois.domreg.merit.edu help\nann-arbor.mi.us\ncog.mi.us\ndst.mi.us\neaton.mi.us\ngen.mi.us\nmus.mi.us\ntec.mi.us\nwashtenaw.mi.us\n\n//
+        uy : http://www.nic.org.uy/\nuy\ncom.uy\nedu.uy\ngub.uy\nmil.uy\nnet.uy\norg.uy\n\n//
+        uz : http://www.reg.uz/\nuz\nco.uz\ncom.uz\nnet.uz\norg.uz\n\n// va : https://www.iana.org/domains/root/db/va.html\nva\n\n//
+        vc : https://www.iana.org/domains/root/db/vc.html\n// Submitted by registry
+        <kshah@ca.afilias.info>\nvc\ncom.vc\nedu.vc\ngov.vc\nmil.vc\nnet.vc\norg.vc\n\n//
+        ve : https://registro.nic.ve/\n// https://nic.ve/site/user-agreement -> under
+        \"III. Clasificaci\xF3n de Nombres de Dominio\"\n// Submitted by registry
+        nic@nic.ve and nicve@conatel.gob.ve\nve\narts.ve\nbib.ve\nco.ve\ncom.ve\ne12.ve\nedu.ve\nemprende.ve\nfirm.ve\ngob.ve\ngov.ve\nia.ve\ninfo.ve\nint.ve\nmil.ve\nnet.ve\nnom.ve\norg.ve\nrar.ve\nrec.ve\nstore.ve\ntec.ve\nweb.ve\n\n//
+        vg : https://www.iana.org/domains/root/db/vg.html\n// Confirmed by registry
+        <tld.ops@centralnic.com> 2025-01-10\nvg\nedu.vg\n\n// vi : https://www.iana.org/domains/root/db/vi.html\nvi\nco.vi\ncom.vi\nk12.vi\nnet.vi\norg.vi\n\n//
+        vn : https://www.vnnic.vn/en/domain/cctld-vn\n// https://vnnic.vn/sites/default/files/tailieu/vn.cctld.domains.txt\nvn\nac.vn\nai.vn\nbiz.vn\ncom.vn\nedu.vn\ngov.vn\nhealth.vn\nid.vn\ninfo.vn\nint.vn\nio.vn\nname.vn\nnet.vn\norg.vn\npro.vn\n\n//
+        vn geographical names\nangiang.vn\nbacgiang.vn\nbackan.vn\nbaclieu.vn\nbacninh.vn\nbaria-vungtau.vn\nbentre.vn\nbinhdinh.vn\nbinhduong.vn\nbinhphuoc.vn\nbinhthuan.vn\ncamau.vn\ncantho.vn\ncaobang.vn\ndaklak.vn\ndaknong.vn\ndanang.vn\ndienbien.vn\ndongnai.vn\ndongthap.vn\ngialai.vn\nhagiang.vn\nhaiduong.vn\nhaiphong.vn\nhanam.vn\nhanoi.vn\nhatinh.vn\nhaugiang.vn\nhoabinh.vn\nhue.vn\nhungyen.vn\nkhanhhoa.vn\nkiengiang.vn\nkontum.vn\nlaichau.vn\nlamdong.vn\nlangson.vn\nlaocai.vn\nlongan.vn\nnamdinh.vn\nnghean.vn\nninhbinh.vn\nninhthuan.vn\nphutho.vn\nphuyen.vn\nquangbinh.vn\nquangnam.vn\nquangngai.vn\nquangninh.vn\nquangtri.vn\nsoctrang.vn\nsonla.vn\ntayninh.vn\nthaibinh.vn\nthainguyen.vn\nthanhhoa.vn\nthanhphohochiminh.vn\nthuathienhue.vn\ntiengiang.vn\ntravinh.vn\ntuyenquang.vn\nvinhlong.vn\nvinhphuc.vn\nyenbai.vn\n\n//
+        vu : https://www.iana.org/domains/root/db/vu.html\n// http://www.vunic.vu/\nvu\ncom.vu\nedu.vu\nnet.vu\norg.vu\n\n//
+        wf : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\nwf\n\n//
+        ws : https://www.iana.org/domains/root/db/ws.html\n// http://samoanic.ws/index.dhtml\nws\ncom.ws\nedu.ws\ngov.ws\nnet.ws\norg.ws\n\n//
+        yt : https://www.afnic.fr/wp-media/uploads/2022/12/afnic-naming-policy-2023-01-01.pdf\nyt\n\n//
+        IDN ccTLDs\n// When submitting patches, please maintain a sort by ISO 3166
+        ccTLD, then\n// U-label, and follow this format:\n// // A-Label (\"<Latin
+        renderings>\", <language name>[, variant info]) : <ISO 3166 ccTLD>\n// //
+        [sponsoring org]\n// U-Label\n\n// xn--mgbaam7a8h (\"Emerat\", Arabic) : AE\n//
+        http://nic.ae/english/arabicdomain/rules.jsp\n\u0627\u0645\u0627\u0631\u0627\u062A\n\n//
+        xn--y9a3aq (\"hye\", Armenian) : AM\n// ISOC AM (operated by .am Registry)\n\u0570\u0561\u0575\n\n//
+        xn--54b7fta0cc (\"Bangla\", Bangla) : BD\n\u09AC\u09BE\u0982\u09B2\u09BE\n\n//
+        xn--90ae (\"bg\", Bulgarian) : BG\n\u0431\u0433\n\n// xn--mgbcpq6gpa1a (\"albahrain\",
+        Arabic) : BH\n\u0627\u0644\u0628\u062D\u0631\u064A\u0646\n\n// xn--90ais (\"bel\",
+        Belarusian/Russian Cyrillic) : BY\n// Operated by .by registry\n\u0431\u0435\u043B\n\n//
+        xn--fiqs8s (\"Zhongguo/China\", Chinese, Simplified) : CN\n// CNNIC\n// https://www.cnnic.cn/11/192/index.html\n\u4E2D\u56FD\n\n//
+        xn--fiqz9s (\"Zhongguo/China\", Chinese, Traditional) : CN\n// CNNIC\n// https://www.cnnic.com.cn/AU/MediaC/Announcement/201609/t20160905_54470.htm\n\u4E2D\u570B\n\n//
+        xn--lgbbat1ad8j (\"Algeria/Al Jazair\", Arabic) : DZ\n\u0627\u0644\u062C\u0632\u0627\u0626\u0631\n\n//
+        xn--wgbh1c (\"Egypt/Masr\", Arabic) : EG\n// http://www.dotmasr.eg/\n\u0645\u0635\u0631\n\n//
+        xn--e1a4c (\"eu\", Cyrillic) : EU\n// https://eurid.eu\n\u0435\u044E\n\n//
+        xn--qxa6a (\"eu\", Greek) : EU\n// https://eurid.eu\n\u03B5\u03C5\n\n// xn--mgbah1a3hjkrd
+        (\"Mauritania\", Arabic) : MR\n\u0645\u0648\u0631\u064A\u062A\u0627\u0646\u064A\u0627\n\n//
+        xn--node (\"ge\", Georgian Mkhedruli) : GE\n\u10D2\u10D4\n\n// xn--qxam (\"el\",
+        Greek) : GR\n// Hellenic Ministry of Infrastructure, Transport, and Networks\n\u03B5\u03BB\n\n//
+        xn--j6w193g (\"Hong Kong\", Chinese) : HK\n// https://www.hkirc.hk\n// Submitted
+        by registry <hk.tech@hkirc.hk>\n// https://www.hkirc.hk/content.jsp?id=30#!/34\n\u9999\u6E2F\n\u500B\u4EBA.\u9999\u6E2F\n\u516C\u53F8.\u9999\u6E2F\n\u653F\u5E9C.\u9999\u6E2F\n\u6559\u80B2.\u9999\u6E2F\n\u7D44\u7E54.\u9999\u6E2F\n\u7DB2\u7D61.\u9999\u6E2F\n\n//
+        xn--2scrj9c (\"Bharat\", Kannada) : IN\n// India\n\u0CAD\u0CBE\u0CB0\u0CA4\n\n//
+        xn--3hcrj9c (\"Bharat\", Oriya) : IN\n// India\n\u0B2D\u0B3E\u0B30\u0B24\n\n//
+        xn--45br5cyl (\"Bharatam\", Assamese) : IN\n// India\n\u09AD\u09BE\u09F0\u09A4\n\n//
+        xn--h2breg3eve (\"Bharatam\", Sanskrit) : IN\n// India\n\u092D\u093E\u0930\u0924\u092E\u094D\n\n//
+        xn--h2brj9c8c (\"Bharot\", Santali) : IN\n// India\n\u092D\u093E\u0930\u094B\u0924\n\n//
+        xn--mgbgu82a (\"Bharat\", Sindhi) : IN\n// India\n\u0680\u0627\u0631\u062A\n\n//
+        xn--rvc1e0am3e (\"Bharatam\", Malayalam) : IN\n// India\n\u0D2D\u0D3E\u0D30\u0D24\u0D02\n\n//
+        xn--h2brj9c (\"Bharat\", Devanagari) : IN\n// India\n\u092D\u093E\u0930\u0924\n\n//
+        xn--mgbbh1a (\"Bharat\", Kashmiri) : IN\n// India\n\u0628\u0627\u0631\u062A\n\n//
+        xn--mgbbh1a71e (\"Bharat\", Arabic) : IN\n// India\n\u0628\u06BE\u0627\u0631\u062A\n\n//
+        xn--fpcrj9c3d (\"Bharat\", Telugu) : IN\n// India\n\u0C2D\u0C3E\u0C30\u0C24\u0C4D\n\n//
+        xn--gecrj9c (\"Bharat\", Gujarati) : IN\n// India\n\u0AAD\u0ABE\u0AB0\u0AA4\n\n//
+        xn--s9brj9c (\"Bharat\", Gurmukhi) : IN\n// India\n\u0A2D\u0A3E\u0A30\u0A24\n\n//
+        xn--45brj9c (\"Bharat\", Bengali) : IN\n// India\n\u09AD\u09BE\u09B0\u09A4\n\n//
+        xn--xkc2dl3a5ee0h (\"India\", Tamil) : IN\n// India\n\u0B87\u0BA8\u0BCD\u0BA4\u0BBF\u0BAF\u0BBE\n\n//
+        xn--mgba3a4f16a (\"Iran\", Persian) : IR\n\u0627\u06CC\u0631\u0627\u0646\n\n//
+        xn--mgba3a4fra (\"Iran\", Arabic) : IR\n\u0627\u064A\u0631\u0627\u0646\n\n//
+        xn--mgbtx2b (\"Iraq\", Arabic) : IQ\n// Communications and Media Commission\n\u0639\u0631\u0627\u0642\n\n//
+        xn--mgbayh7gpa (\"al-Ordon\", Arabic) : JO\n// National Information Technology
+        Center (NITC)\n// Royal Scientific Society, Al-Jubeiha\n\u0627\u0644\u0627\u0631\u062F\u0646\n\n//
+        xn--3e0b707e (\"Republic of Korea\", Hangul) : KR\n\uD55C\uAD6D\n\n// xn--80ao21a
+        (\"Kaz\", Kazakh) : KZ\n\u049B\u0430\u0437\n\n// xn--q7ce6a (\"Lao\", Lao)
+        : LA\n\u0EA5\u0EB2\u0EA7\n\n// xn--fzc2c9e2c (\"Lanka\", Sinhalese-Sinhala)
+        : LK\n// https://nic.lk\n\u0DBD\u0D82\u0D9A\u0DCF\n\n// xn--xkc2al3hye2a (\"Ilangai\",
+        Tamil) : LK\n// https://nic.lk\n\u0B87\u0BB2\u0B99\u0BCD\u0B95\u0BC8\n\n//
+        xn--mgbc0a9azcg (\"Morocco/al-Maghrib\", Arabic) : MA\n\u0627\u0644\u0645\u063A\u0631\u0628\n\n//
+        xn--d1alf (\"mkd\", Macedonian) : MK\n// MARnet\n\u043C\u043A\u0434\n\n//
+        xn--l1acc (\"mon\", Mongolian) : MN\n\u043C\u043E\u043D\n\n// xn--mix891f
+        (\"Macao\", Chinese, Traditional) : MO\n// MONIC / HNET Asia (Registry Operator
+        for .mo)\n\u6FB3\u9580\n\n// xn--mix082f (\"Macao\", Chinese, Simplified)
+        : MO\n\u6FB3\u95E8\n\n// xn--mgbx4cd0ab (\"Malaysia\", Malay) : MY\n\u0645\u0644\u064A\u0633\u064A\u0627\n\n//
+        xn--mgb9awbf (\"Oman\", Arabic) : OM\n\u0639\u0645\u0627\u0646\n\n// xn--mgbai9azgqp6j
+        (\"Pakistan\", Urdu/Arabic) : PK\n\u067E\u0627\u06A9\u0633\u062A\u0627\u0646\n\n//
+        xn--mgbai9a5eva00b (\"Pakistan\", Urdu/Arabic, variant) : PK\n\u067E\u0627\u0643\u0633\u062A\u0627\u0646\n\n//
+        xn--ygbi2ammx (\"Falasteen\", Arabic) : PS\n// The Palestinian National Internet
+        Naming Authority (PNINA)\n// http://www.pnina.ps\n\u0641\u0644\u0633\u0637\u064A\u0646\n\n//
+        xn--90a3ac (\"srb\", Cyrillic) : RS\n// https://www.rnids.rs/en/domains/national-domains\n\u0441\u0440\u0431\n\u0430\u043A.\u0441\u0440\u0431\n\u043E\u0431\u0440.\u0441\u0440\u0431\n\u043E\u0434.\u0441\u0440\u0431\n\u043E\u0440\u0433.\u0441\u0440\u0431\n\u043F\u0440.\u0441\u0440\u0431\n\u0443\u043F\u0440.\u0441\u0440\u0431\n\n//
+        xn--p1ai (\"rf\", Russian-Cyrillic) : RU\n// https://cctld.ru/files/pdf/docs/en/rules_ru-rf.pdf\n//
+        Submitted by George Georgievsky <gug@cctld.ru>\n\u0440\u0444\n\n// xn--wgbl6a
+        (\"Qatar\", Arabic) : QA\n// http://www.ict.gov.qa/\n\u0642\u0637\u0631\n\n//
+        xn--mgberp4a5d4ar (\"AlSaudiah\", Arabic) : SA\n// http://www.nic.net.sa/\n\u0627\u0644\u0633\u0639\u0648\u062F\u064A\u0629\n\n//
+        xn--mgberp4a5d4a87g (\"AlSaudiah\", Arabic, variant): SA\n\u0627\u0644\u0633\u0639\u0648\u062F\u06CC\u0629\n\n//
+        xn--mgbqly7c0a67fbc (\"AlSaudiah\", Arabic, variant) : SA\n\u0627\u0644\u0633\u0639\u0648\u062F\u06CC\u06C3\n\n//
+        xn--mgbqly7cvafr (\"AlSaudiah\", Arabic, variant) : SA\n\u0627\u0644\u0633\u0639\u0648\u062F\u064A\u0647\n\n//
+        xn--mgbpl2fh (\"sudan\", Arabic) : SD\n// Operated by .sd registry\n\u0633\u0648\u062F\u0627\u0646\n\n//
+        xn--yfro4i67o Singapore (\"Singapore\", Chinese) : SG\n\u65B0\u52A0\u5761\n\n//
+        xn--clchc0ea0b2g2a9gcd (\"Singapore\", Tamil) : SG\n\u0B9A\u0BBF\u0B99\u0BCD\u0B95\u0BAA\u0BCD\u0BAA\u0BC2\u0BB0\u0BCD\n\n//
+        xn--ogbpf8fl (\"Syria\", Arabic) : SY\n\u0633\u0648\u0631\u064A\u0629\n\n//
+        xn--mgbtf8fl (\"Syria\", Arabic, variant) : SY\n\u0633\u0648\u0631\u064A\u0627\n\n//
+        xn--o3cw4h (\"Thai\", Thai) : TH\n// http://www.thnic.co.th\n\u0E44\u0E17\u0E22\n\u0E17\u0E2B\u0E32\u0E23.\u0E44\u0E17\u0E22\n\u0E18\u0E38\u0E23\u0E01\u0E34\u0E08.\u0E44\u0E17\u0E22\n\u0E40\u0E19\u0E47\u0E15.\u0E44\u0E17\u0E22\n\u0E23\u0E31\u0E10\u0E1A\u0E32\u0E25.\u0E44\u0E17\u0E22\n\u0E28\u0E36\u0E01\u0E29\u0E32.\u0E44\u0E17\u0E22\n\u0E2D\u0E07\u0E04\u0E4C\u0E01\u0E23.\u0E44\u0E17\u0E22\n\n//
+        xn--pgbs0dh (\"Tunisia\", Arabic) : TN\n// http://nic.tn\n\u062A\u0648\u0646\u0633\n\n//
+        xn--kpry57d (\"Taiwan\", Chinese, Traditional) : TW\n// https://twnic.tw/dnservice_catag.php\n\u53F0\u7063\n\n//
+        xn--kprw13d (\"Taiwan\", Chinese, Simplified) : TW\n// http://www.twnic.net/english/dn/dn_07a.htm\n\u53F0\u6E7E\n\n//
+        xn--nnx388a (\"Taiwan\", Chinese, variant) : TW\n\u81FA\u7063\n\n// xn--j1amh
+        (\"ukr\", Cyrillic) : UA\n\u0443\u043A\u0440\n\n// xn--mgb2ddes (\"AlYemen\",
+        Arabic) : YE\n\u0627\u0644\u064A\u0645\u0646\n\n// xxx : http://icmregistry.com\nxxx\n\n//
+        ye : http://www.y.net.ye/services/domain_name.htm\nye\ncom.ye\nedu.ye\ngov.ye\nmil.ye\nnet.ye\norg.ye\n\n//
+        za : https://www.iana.org/domains/root/db/za.html\nac.za\nagric.za\nalt.za\nco.za\nedu.za\ngov.za\ngrondar.za\nlaw.za\nmil.za\nnet.za\nngo.za\nnic.za\nnis.za\nnom.za\norg.za\nschool.za\ntm.za\nweb.za\n\n//
+        zm : https://zicta.zm/\n// Submitted by registry <info@zicta.zm>\nzm\nac.zm\nbiz.zm\nco.zm\ncom.zm\nedu.zm\ngov.zm\ninfo.zm\nmil.zm\nnet.zm\norg.zm\nsch.zm\n\n//
+        zw : https://www.potraz.gov.zw/\n// Confirmed by registry <bmtengwa@potraz.gov.zw>
+        2017-01-25\nzw\nac.zw\nco.zw\ngov.zw\nmil.zw\norg.zw\n\n// newGTLDs\n\n//
+        List of new gTLDs imported from https://www.icann.org/resources/registries/gtlds/v2/gtlds.json
+        on 2026-04-15T16:04:02Z\n// This list is auto-generated, don't edit it manually.\n//
+        aaa : American Automobile Association, Inc.\n// https://www.iana.org/domains/root/db/aaa.html\naaa\n\n//
+        aarp : AARP\n// https://www.iana.org/domains/root/db/aarp.html\naarp\n\n//
+        abb : ABB Ltd\n// https://www.iana.org/domains/root/db/abb.html\nabb\n\n//
+        abbott : Abbott Laboratories, Inc.\n// https://www.iana.org/domains/root/db/abbott.html\nabbott\n\n//
+        abbvie : AbbVie Inc.\n// https://www.iana.org/domains/root/db/abbvie.html\nabbvie\n\n//
+        abc : Disney Enterprises, Inc.\n// https://www.iana.org/domains/root/db/abc.html\nabc\n\n//
+        able : Able Inc.\n// https://www.iana.org/domains/root/db/able.html\nable\n\n//
+        abogado : Registry Services, LLC\n// https://www.iana.org/domains/root/db/abogado.html\nabogado\n\n//
+        abudhabi : Abu Dhabi Systems and Information Centre\n// https://www.iana.org/domains/root/db/abudhabi.html\nabudhabi\n\n//
+        academy : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/academy.html\nacademy\n\n//
+        accenture : Accenture plc\n// https://www.iana.org/domains/root/db/accenture.html\naccenture\n\n//
+        accountant : dot Accountant Limited\n// https://www.iana.org/domains/root/db/accountant.html\naccountant\n\n//
+        accountants : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/accountants.html\naccountants\n\n//
+        aco : ACO Severin Ahlmann GmbH & Co. KG\n// https://www.iana.org/domains/root/db/aco.html\naco\n\n//
+        actor : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/actor.html\nactor\n\n//
+        ads : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/ads.html\nads\n\n//
+        adult : ICM Registry AD LLC\n// https://www.iana.org/domains/root/db/adult.html\nadult\n\n//
+        aeg : Aktiebolaget Electrolux\n// https://www.iana.org/domains/root/db/aeg.html\naeg\n\n//
+        aetna : Aetna Life Insurance Company\n// https://www.iana.org/domains/root/db/aetna.html\naetna\n\n//
+        afl : Australian Football League\n// https://www.iana.org/domains/root/db/afl.html\nafl\n\n//
+        africa : ZA Central Registry NPC trading as Registry.Africa\n// https://www.iana.org/domains/root/db/africa.html\nafrica\n\n//
+        agakhan : Fondation Aga Khan (Aga Khan Foundation)\n// https://www.iana.org/domains/root/db/agakhan.html\nagakhan\n\n//
+        agency : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/agency.html\nagency\n\n//
+        aig : American International Group, Inc.\n// https://www.iana.org/domains/root/db/aig.html\naig\n\n//
+        airbus : Airbus S.A.S.\n// https://www.iana.org/domains/root/db/airbus.html\nairbus\n\n//
+        airforce : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/airforce.html\nairforce\n\n//
+        airtel : Bharti Airtel Limited\n// https://www.iana.org/domains/root/db/airtel.html\nairtel\n\n//
+        akdn : Fondation Aga Khan (Aga Khan Foundation)\n// https://www.iana.org/domains/root/db/akdn.html\nakdn\n\n//
+        alibaba : Alibaba Group Holding Limited\n// https://www.iana.org/domains/root/db/alibaba.html\nalibaba\n\n//
+        alipay : Alibaba Group Holding Limited\n// https://www.iana.org/domains/root/db/alipay.html\nalipay\n\n//
+        allfinanz : Allfinanz Deutsche Verm\xF6gensberatung Aktiengesellschaft\n//
+        https://www.iana.org/domains/root/db/allfinanz.html\nallfinanz\n\n// allstate
+        : Allstate Fire and Casualty Insurance Company\n// https://www.iana.org/domains/root/db/allstate.html\nallstate\n\n//
+        ally : Ally Financial Inc.\n// https://www.iana.org/domains/root/db/ally.html\nally\n\n//
+        alsace : Region Grand Est\n// https://www.iana.org/domains/root/db/alsace.html\nalsace\n\n//
+        alstom : ALSTOM\n// https://www.iana.org/domains/root/db/alstom.html\nalstom\n\n//
+        amazon : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/amazon.html\namazon\n\n//
+        americanexpress : American Express Travel Related Services Company, Inc.\n//
+        https://www.iana.org/domains/root/db/americanexpress.html\namericanexpress\n\n//
+        americanfamily : AmFam, Inc.\n// https://www.iana.org/domains/root/db/americanfamily.html\namericanfamily\n\n//
+        amex : American Express Travel Related Services Company, Inc.\n// https://www.iana.org/domains/root/db/amex.html\namex\n\n//
+        amfam : AmFam, Inc.\n// https://www.iana.org/domains/root/db/amfam.html\namfam\n\n//
+        amica : Amica Mutual Insurance Company\n// https://www.iana.org/domains/root/db/amica.html\namica\n\n//
+        amsterdam : Gemeente Amsterdam\n// https://www.iana.org/domains/root/db/amsterdam.html\namsterdam\n\n//
+        analytics : Campus IP LLC\n// https://www.iana.org/domains/root/db/analytics.html\nanalytics\n\n//
+        android : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/android.html\nandroid\n\n//
+        anquan : Beijing Qihu Keji Co., Ltd.\n// https://www.iana.org/domains/root/db/anquan.html\nanquan\n\n//
+        anz : Australia and New Zealand Banking Group Limited\n// https://www.iana.org/domains/root/db/anz.html\nanz\n\n//
+        aol : Yahoo Inc.\n// https://www.iana.org/domains/root/db/aol.html\naol\n\n//
+        apartments : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/apartments.html\napartments\n\n//
+        app : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/app.html\napp\n\n//
+        apple : Apple Inc.\n// https://www.iana.org/domains/root/db/apple.html\napple\n\n//
+        aquarelle : Aquarelle.com\n// https://www.iana.org/domains/root/db/aquarelle.html\naquarelle\n\n//
+        arab : League of Arab States\n// https://www.iana.org/domains/root/db/arab.html\narab\n\n//
+        aramco : Aramco Services Company\n// https://www.iana.org/domains/root/db/aramco.html\naramco\n\n//
+        archi : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/archi.html\narchi\n\n//
+        army : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/army.html\narmy\n\n//
+        art : UK Creative Ideas Limited\n// https://www.iana.org/domains/root/db/art.html\nart\n\n//
+        arte : Association Relative \xE0 la T\xE9l\xE9vision Europ\xE9enne G.E.I.E.\n//
+        https://www.iana.org/domains/root/db/arte.html\narte\n\n// asda : Asda Stores
+        Limited\n// https://www.iana.org/domains/root/db/asda.html\nasda\n\n// associates
+        : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/associates.html\nassociates\n\n//
+        athleta : The Gap, Inc.\n// https://www.iana.org/domains/root/db/athleta.html\nathleta\n\n//
+        attorney : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/attorney.html\nattorney\n\n//
+        auction : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/auction.html\nauction\n\n//
+        audi : AUDI Aktiengesellschaft\n// https://www.iana.org/domains/root/db/audi.html\naudi\n\n//
+        audible : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/audible.html\naudible\n\n//
+        audio : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/audio.html\naudio\n\n//
+        auspost : Australian Postal Corporation\n// https://www.iana.org/domains/root/db/auspost.html\nauspost\n\n//
+        author : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/author.html\nauthor\n\n//
+        auto : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/auto.html\nauto\n\n//
+        autos : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/autos.html\nautos\n\n//
+        aws : AWS Registry LLC\n// https://www.iana.org/domains/root/db/aws.html\naws\n\n//
+        axa : AXA Group Operations SAS\n// https://www.iana.org/domains/root/db/axa.html\naxa\n\n//
+        azure : Microsoft Corporation\n// https://www.iana.org/domains/root/db/azure.html\nazure\n\n//
+        baby : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/baby.html\nbaby\n\n//
+        baidu : Baidu, Inc.\n// https://www.iana.org/domains/root/db/baidu.html\nbaidu\n\n//
+        banamex : Citigroup Inc.\n// https://www.iana.org/domains/root/db/banamex.html\nbanamex\n\n//
+        band : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/band.html\nband\n\n//
+        bank : fTLD Registry Services LLC\n// https://www.iana.org/domains/root/db/bank.html\nbank\n\n//
+        bar : Punto 2012 Sociedad Anonima Promotora de Inversion de Capital Variable\n//
+        https://www.iana.org/domains/root/db/bar.html\nbar\n\n// barcelona : Municipi
+        de Barcelona\n// https://www.iana.org/domains/root/db/barcelona.html\nbarcelona\n\n//
+        barclaycard : Barclays Bank PLC\n// https://www.iana.org/domains/root/db/barclaycard.html\nbarclaycard\n\n//
+        barclays : Barclays Bank PLC\n// https://www.iana.org/domains/root/db/barclays.html\nbarclays\n\n//
+        barefoot : Gallo Vineyards, Inc.\n// https://www.iana.org/domains/root/db/barefoot.html\nbarefoot\n\n//
+        bargains : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/bargains.html\nbargains\n\n//
+        baseball : MLB Advanced Media DH, LLC\n// https://www.iana.org/domains/root/db/baseball.html\nbaseball\n\n//
+        basketball : F\xE9d\xE9ration Internationale de Basketball (FIBA)\n// https://www.iana.org/domains/root/db/basketball.html\nbasketball\n\n//
+        bauhaus : Werkhaus GmbH\n// https://www.iana.org/domains/root/db/bauhaus.html\nbauhaus\n\n//
+        bayern : Bayern Connect GmbH\n// https://www.iana.org/domains/root/db/bayern.html\nbayern\n\n//
+        bbc : British Broadcasting Corporation\n// https://www.iana.org/domains/root/db/bbc.html\nbbc\n\n//
+        bbt : BB&T Corporation\n// https://www.iana.org/domains/root/db/bbt.html\nbbt\n\n//
+        bbva : BANCO BILBAO VIZCAYA ARGENTARIA, S.A.\n// https://www.iana.org/domains/root/db/bbva.html\nbbva\n\n//
+        bcg : The Boston Consulting Group, Inc.\n// https://www.iana.org/domains/root/db/bcg.html\nbcg\n\n//
+        bcn : Municipi de Barcelona\n// https://www.iana.org/domains/root/db/bcn.html\nbcn\n\n//
+        beats : Beats Electronics, LLC\n// https://www.iana.org/domains/root/db/beats.html\nbeats\n\n//
+        beauty : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/beauty.html\nbeauty\n\n//
+        beer : Registry Services, LLC\n// https://www.iana.org/domains/root/db/beer.html\nbeer\n\n//
+        berlin : dotBERLIN GmbH & Co. KG\n// https://www.iana.org/domains/root/db/berlin.html\nberlin\n\n//
+        best : BestTLD Pty Ltd\n// https://www.iana.org/domains/root/db/best.html\nbest\n\n//
+        bestbuy : BBY Solutions, Inc.\n// https://www.iana.org/domains/root/db/bestbuy.html\nbestbuy\n\n//
+        bet : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/bet.html\nbet\n\n//
+        bharti : Bharti Enterprises (Holding) Private Limited\n// https://www.iana.org/domains/root/db/bharti.html\nbharti\n\n//
+        bible : American Bible Society\n// https://www.iana.org/domains/root/db/bible.html\nbible\n\n//
+        bid : dot Bid Limited\n// https://www.iana.org/domains/root/db/bid.html\nbid\n\n//
+        bike : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/bike.html\nbike\n\n//
+        bing : Microsoft Corporation\n// https://www.iana.org/domains/root/db/bing.html\nbing\n\n//
+        bingo : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/bingo.html\nbingo\n\n//
+        bio : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/bio.html\nbio\n\n//
+        black : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/black.html\nblack\n\n//
+        blackfriday : Registry Services, LLC\n// https://www.iana.org/domains/root/db/blackfriday.html\nblackfriday\n\n//
+        blockbuster : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/blockbuster.html\nblockbuster\n\n//
+        blog : Knock Knock WHOIS There, LLC\n// https://www.iana.org/domains/root/db/blog.html\nblog\n\n//
+        bloomberg : Bloomberg IP Holdings LLC\n// https://www.iana.org/domains/root/db/bloomberg.html\nbloomberg\n\n//
+        blue : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/blue.html\nblue\n\n//
+        bms : Bristol-Myers Squibb Company\n// https://www.iana.org/domains/root/db/bms.html\nbms\n\n//
+        bmw : Bayerische Motoren Werke Aktiengesellschaft\n// https://www.iana.org/domains/root/db/bmw.html\nbmw\n\n//
+        bnpparibas : BNP Paribas\n// https://www.iana.org/domains/root/db/bnpparibas.html\nbnpparibas\n\n//
+        boats : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/boats.html\nboats\n\n//
+        boehringer : Boehringer Ingelheim International GmbH\n// https://www.iana.org/domains/root/db/boehringer.html\nboehringer\n\n//
+        bofa : Bank of America Corporation\n// https://www.iana.org/domains/root/db/bofa.html\nbofa\n\n//
+        bom : N\xFAcleo de Informa\xE7\xE3o e Coordena\xE7\xE3o do Ponto BR - NIC.br\n//
+        https://www.iana.org/domains/root/db/bom.html\nbom\n\n// bond : ShortDot SA\n//
+        https://www.iana.org/domains/root/db/bond.html\nbond\n\n// boo : Charleston
+        Road Registry Inc.\n// https://www.iana.org/domains/root/db/boo.html\nboo\n\n//
+        book : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/book.html\nbook\n\n//
+        booking : Booking.com B.V.\n// https://www.iana.org/domains/root/db/booking.html\nbooking\n\n//
+        bosch : Robert Bosch GMBH\n// https://www.iana.org/domains/root/db/bosch.html\nbosch\n\n//
+        bostik : Bostik SA\n// https://www.iana.org/domains/root/db/bostik.html\nbostik\n\n//
+        boston : Registry Services, LLC\n// https://www.iana.org/domains/root/db/boston.html\nboston\n\n//
+        bot : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/bot.html\nbot\n\n//
+        boutique : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/boutique.html\nboutique\n\n//
+        box : Intercap Registry Inc.\n// https://www.iana.org/domains/root/db/box.html\nbox\n\n//
+        bradesco : Banco Bradesco S.A.\n// https://www.iana.org/domains/root/db/bradesco.html\nbradesco\n\n//
+        bridgestone : Bridgestone Corporation\n// https://www.iana.org/domains/root/db/bridgestone.html\nbridgestone\n\n//
+        broadway : Celebrate Broadway, Inc.\n// https://www.iana.org/domains/root/db/broadway.html\nbroadway\n\n//
+        broker : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/broker.html\nbroker\n\n//
+        brother : Brother Industries, Ltd.\n// https://www.iana.org/domains/root/db/brother.html\nbrother\n\n//
+        brussels : DNS.be vzw\n// https://www.iana.org/domains/root/db/brussels.html\nbrussels\n\n//
+        build : Plan Bee LLC\n// https://www.iana.org/domains/root/db/build.html\nbuild\n\n//
+        builders : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/builders.html\nbuilders\n\n//
+        business : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/business.html\nbusiness\n\n//
+        buy : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/buy.html\nbuy\n\n//
+        buzz : DOTSTRATEGY CO.\n// https://www.iana.org/domains/root/db/buzz.html\nbuzz\n\n//
+        bzh : Association www.bzh\n// https://www.iana.org/domains/root/db/bzh.html\nbzh\n\n//
+        cab : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cab.html\ncab\n\n//
+        cafe : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cafe.html\ncafe\n\n//
+        cal : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/cal.html\ncal\n\n//
+        call : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/call.html\ncall\n\n//
+        calvinklein : PVH gTLD Holdings LLC\n// https://www.iana.org/domains/root/db/calvinklein.html\ncalvinklein\n\n//
+        cam : Cam Connecting SARL\n// https://www.iana.org/domains/root/db/cam.html\ncam\n\n//
+        camera : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/camera.html\ncamera\n\n//
+        camp : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/camp.html\ncamp\n\n//
+        canon : Canon Inc.\n// https://www.iana.org/domains/root/db/canon.html\ncanon\n\n//
+        capetown : ZA Central Registry NPC trading as ZA Central Registry\n// https://www.iana.org/domains/root/db/capetown.html\ncapetown\n\n//
+        capital : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/capital.html\ncapital\n\n//
+        capitalone : Capital One Financial Corporation\n// https://www.iana.org/domains/root/db/capitalone.html\ncapitalone\n\n//
+        car : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/car.html\ncar\n\n//
+        caravan : Caravan International, Inc.\n// https://www.iana.org/domains/root/db/caravan.html\ncaravan\n\n//
+        cards : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cards.html\ncards\n\n//
+        care : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/care.html\ncare\n\n//
+        career : dotCareer LLC\n// https://www.iana.org/domains/root/db/career.html\ncareer\n\n//
+        careers : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/careers.html\ncareers\n\n//
+        cars : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/cars.html\ncars\n\n//
+        casa : Registry Services, LLC\n// https://www.iana.org/domains/root/db/casa.html\ncasa\n\n//
+        case : Digity, LLC\n// https://www.iana.org/domains/root/db/case.html\ncase\n\n//
+        cash : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cash.html\ncash\n\n//
+        casino : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/casino.html\ncasino\n\n//
+        catering : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/catering.html\ncatering\n\n//
+        catholic : Pontificium Consilium de Comunicationibus Socialibus (PCCS) (Pontifical
+        Council for Social Communication)\n// https://www.iana.org/domains/root/db/catholic.html\ncatholic\n\n//
+        cba : COMMONWEALTH BANK OF AUSTRALIA\n// https://www.iana.org/domains/root/db/cba.html\ncba\n\n//
+        cbn : The Christian Broadcasting Network, Inc.\n// https://www.iana.org/domains/root/db/cbn.html\ncbn\n\n//
+        cbre : CBRE, Inc.\n// https://www.iana.org/domains/root/db/cbre.html\ncbre\n\n//
+        center : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/center.html\ncenter\n\n//
+        ceo : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/ceo.html\nceo\n\n//
+        cern : European Organization for Nuclear Research (\"CERN\")\n// https://www.iana.org/domains/root/db/cern.html\ncern\n\n//
+        cfa : CFA Institute\n// https://www.iana.org/domains/root/db/cfa.html\ncfa\n\n//
+        cfd : ShortDot SA\n// https://www.iana.org/domains/root/db/cfd.html\ncfd\n\n//
+        chanel : Chanel International B.V.\n// https://www.iana.org/domains/root/db/chanel.html\nchanel\n\n//
+        channel : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/channel.html\nchannel\n\n//
+        charity : Public Interest Registry\n// https://www.iana.org/domains/root/db/charity.html\ncharity\n\n//
+        chase : JPMorgan Chase Bank, National Association\n// https://www.iana.org/domains/root/db/chase.html\nchase\n\n//
+        chat : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/chat.html\nchat\n\n//
+        cheap : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cheap.html\ncheap\n\n//
+        chintai : CHINTAI Corporation\n// https://www.iana.org/domains/root/db/chintai.html\nchintai\n\n//
+        christmas : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/christmas.html\nchristmas\n\n//
+        chrome : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/chrome.html\nchrome\n\n//
+        church : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/church.html\nchurch\n\n//
+        cipriani : Hotel Cipriani Srl\n// https://www.iana.org/domains/root/db/cipriani.html\ncipriani\n\n//
+        circle : Jolly Host, LLC\n// https://www.iana.org/domains/root/db/circle.html\ncircle\n\n//
+        cisco : Cisco Technology, Inc.\n// https://www.iana.org/domains/root/db/cisco.html\ncisco\n\n//
+        citadel : Citadel Domain LLC\n// https://www.iana.org/domains/root/db/citadel.html\ncitadel\n\n//
+        citi : Citigroup Inc.\n// https://www.iana.org/domains/root/db/citi.html\nciti\n\n//
+        citic : CITIC Group Corporation\n// https://www.iana.org/domains/root/db/citic.html\ncitic\n\n//
+        city : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/city.html\ncity\n\n//
+        claims : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/claims.html\nclaims\n\n//
+        cleaning : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cleaning.html\ncleaning\n\n//
+        click : Waterford Limited\n// https://www.iana.org/domains/root/db/click.html\nclick\n\n//
+        clinic : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/clinic.html\nclinic\n\n//
+        clinique : The Est\xE9e Lauder Companies Inc.\n// https://www.iana.org/domains/root/db/clinique.html\nclinique\n\n//
+        clothing : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/clothing.html\nclothing\n\n//
+        cloud : Aruba PEC S.p.A.\n// https://www.iana.org/domains/root/db/cloud.html\ncloud\n\n//
+        club : Registry Services, LLC\n// https://www.iana.org/domains/root/db/club.html\nclub\n\n//
+        clubmed : Club M\xE9diterran\xE9e S.A.\n// https://www.iana.org/domains/root/db/clubmed.html\nclubmed\n\n//
+        coach : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/coach.html\ncoach\n\n//
+        codes : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/codes.html\ncodes\n\n//
+        coffee : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/coffee.html\ncoffee\n\n//
+        college : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/college.html\ncollege\n\n//
+        cologne : dotKoeln GmbH\n// https://www.iana.org/domains/root/db/cologne.html\ncologne\n\n//
+        commbank : COMMONWEALTH BANK OF AUSTRALIA\n// https://www.iana.org/domains/root/db/commbank.html\ncommbank\n\n//
+        community : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/community.html\ncommunity\n\n//
+        company : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/company.html\ncompany\n\n//
+        compare : Registry Services, LLC\n// https://www.iana.org/domains/root/db/compare.html\ncompare\n\n//
+        computer : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/computer.html\ncomputer\n\n//
+        comsec : VeriSign, Inc.\n// https://www.iana.org/domains/root/db/comsec.html\ncomsec\n\n//
+        condos : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/condos.html\ncondos\n\n//
+        construction : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/construction.html\nconstruction\n\n//
+        consulting : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/consulting.html\nconsulting\n\n//
+        contact : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/contact.html\ncontact\n\n//
+        contractors : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/contractors.html\ncontractors\n\n//
+        cooking : Registry Services, LLC\n// https://www.iana.org/domains/root/db/cooking.html\ncooking\n\n//
+        cool : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cool.html\ncool\n\n//
+        corsica : Collectivit\xE9 de Corse\n// https://www.iana.org/domains/root/db/corsica.html\ncorsica\n\n//
+        country : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/country.html\ncountry\n\n//
+        coupon : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/coupon.html\ncoupon\n\n//
+        coupons : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/coupons.html\ncoupons\n\n//
+        courses : Registry Services, LLC\n// https://www.iana.org/domains/root/db/courses.html\ncourses\n\n//
+        cpa : American Institute of Certified Public Accountants\n// https://www.iana.org/domains/root/db/cpa.html\ncpa\n\n//
+        credit : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/credit.html\ncredit\n\n//
+        creditcard : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/creditcard.html\ncreditcard\n\n//
+        creditunion : DotCooperation LLC\n// https://www.iana.org/domains/root/db/creditunion.html\ncreditunion\n\n//
+        cricket : dot Cricket Limited\n// https://www.iana.org/domains/root/db/cricket.html\ncricket\n\n//
+        crown : Crown Equipment Corporation\n// https://www.iana.org/domains/root/db/crown.html\ncrown\n\n//
+        crs : Federated Co-operatives Limited\n// https://www.iana.org/domains/root/db/crs.html\ncrs\n\n//
+        cruise : Viking River Cruises (Bermuda) Ltd.\n// https://www.iana.org/domains/root/db/cruise.html\ncruise\n\n//
+        cruises : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/cruises.html\ncruises\n\n//
+        cuisinella : SCHMIDT GROUPE S.A.S.\n// https://www.iana.org/domains/root/db/cuisinella.html\ncuisinella\n\n//
+        cymru : Nominet UK\n// https://www.iana.org/domains/root/db/cymru.html\ncymru\n\n//
+        cyou : ShortDot SA\n// https://www.iana.org/domains/root/db/cyou.html\ncyou\n\n//
+        dad : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/dad.html\ndad\n\n//
+        dance : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/dance.html\ndance\n\n//
+        data : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/data.html\ndata\n\n//
+        date : dot Date Limited\n// https://www.iana.org/domains/root/db/date.html\ndate\n\n//
+        dating : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/dating.html\ndating\n\n//
+        datsun : NISSAN MOTOR CO., LTD.\n// https://www.iana.org/domains/root/db/datsun.html\ndatsun\n\n//
+        day : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/day.html\nday\n\n//
+        dclk : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/dclk.html\ndclk\n\n//
+        dds : Registry Services, LLC\n// https://www.iana.org/domains/root/db/dds.html\ndds\n\n//
+        deal : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/deal.html\ndeal\n\n//
+        dealer : Intercap Registry Inc.\n// https://www.iana.org/domains/root/db/dealer.html\ndealer\n\n//
+        deals : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/deals.html\ndeals\n\n//
+        degree : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/degree.html\ndegree\n\n//
+        delivery : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/delivery.html\ndelivery\n\n//
+        dell : Dell Inc.\n// https://www.iana.org/domains/root/db/dell.html\ndell\n\n//
+        deloitte : Deloitte Touche Tohmatsu\n// https://www.iana.org/domains/root/db/deloitte.html\ndeloitte\n\n//
+        delta : Delta Air Lines, Inc.\n// https://www.iana.org/domains/root/db/delta.html\ndelta\n\n//
+        democrat : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/democrat.html\ndemocrat\n\n//
+        dental : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/dental.html\ndental\n\n//
+        dentist : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/dentist.html\ndentist\n\n//
+        desi\n// https://www.iana.org/domains/root/db/desi.html\ndesi\n\n// design
+        : Registry Services, LLC\n// https://www.iana.org/domains/root/db/design.html\ndesign\n\n//
+        dev : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/dev.html\ndev\n\n//
+        dhl : Deutsche Post AG\n// https://www.iana.org/domains/root/db/dhl.html\ndhl\n\n//
+        diamonds : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/diamonds.html\ndiamonds\n\n//
+        diet : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/diet.html\ndiet\n\n//
+        digital : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/digital.html\ndigital\n\n//
+        direct : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/direct.html\ndirect\n\n//
+        directory : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/directory.html\ndirectory\n\n//
+        discount : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/discount.html\ndiscount\n\n//
+        discover : Discover Financial Services\n// https://www.iana.org/domains/root/db/discover.html\ndiscover\n\n//
+        dish : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/dish.html\ndish\n\n//
+        diy : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/diy.html\ndiy\n\n//
+        dnp : Dai Nippon Printing Co., Ltd.\n// https://www.iana.org/domains/root/db/dnp.html\ndnp\n\n//
+        docs : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/docs.html\ndocs\n\n//
+        doctor : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/doctor.html\ndoctor\n\n//
+        dog : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/dog.html\ndog\n\n//
+        domains : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/domains.html\ndomains\n\n//
+        dot : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/dot.html\ndot\n\n//
+        download : dot Support Limited\n// https://www.iana.org/domains/root/db/download.html\ndownload\n\n//
+        drive : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/drive.html\ndrive\n\n//
+        dtv : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/dtv.html\ndtv\n\n//
+        dubai : Dubai Smart Government Department\n// https://www.iana.org/domains/root/db/dubai.html\ndubai\n\n//
+        dupont : DuPont Specialty Products USA, LLC\n// https://www.iana.org/domains/root/db/dupont.html\ndupont\n\n//
+        durban : ZA Central Registry NPC trading as ZA Central Registry\n// https://www.iana.org/domains/root/db/durban.html\ndurban\n\n//
+        dvag : Deutsche Verm\xF6gensberatung Aktiengesellschaft DVAG\n// https://www.iana.org/domains/root/db/dvag.html\ndvag\n\n//
+        dvr : DISH Technologies L.L.C.\n// https://www.iana.org/domains/root/db/dvr.html\ndvr\n\n//
+        earth : Interlink Systems Innovation Institute K.K.\n// https://www.iana.org/domains/root/db/earth.html\nearth\n\n//
+        eat : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/eat.html\neat\n\n//
+        eco : Big Room Inc.\n// https://www.iana.org/domains/root/db/eco.html\neco\n\n//
+        edeka : EDEKA Verband kaufm\xE4nnischer Genossenschaften e.V.\n// https://www.iana.org/domains/root/db/edeka.html\nedeka\n\n//
+        education : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/education.html\neducation\n\n//
+        email : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/email.html\nemail\n\n//
+        emerck : Merck KGaA\n// https://www.iana.org/domains/root/db/emerck.html\nemerck\n\n//
+        energy : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/energy.html\nenergy\n\n//
+        engineer : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/engineer.html\nengineer\n\n//
+        engineering : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/engineering.html\nengineering\n\n//
+        enterprises : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/enterprises.html\nenterprises\n\n//
+        epson : Seiko Epson Corporation\n// https://www.iana.org/domains/root/db/epson.html\nepson\n\n//
+        equipment : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/equipment.html\nequipment\n\n//
+        ericsson : Telefonaktiebolaget L M Ericsson\n// https://www.iana.org/domains/root/db/ericsson.html\nericsson\n\n//
+        erni : ERNI Group Holding AG\n// https://www.iana.org/domains/root/db/erni.html\nerni\n\n//
+        esq : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/esq.html\nesq\n\n//
+        estate : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/estate.html\nestate\n\n//
+        eurovision : European Broadcasting Union (EBU)\n// https://www.iana.org/domains/root/db/eurovision.html\neurovision\n\n//
+        eus : Puntueus Fundazioa\n// https://www.iana.org/domains/root/db/eus.html\neus\n\n//
+        events : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/events.html\nevents\n\n//
+        exchange : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/exchange.html\nexchange\n\n//
+        expert : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/expert.html\nexpert\n\n//
+        exposed : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/exposed.html\nexposed\n\n//
+        express : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/express.html\nexpress\n\n//
+        extraspace : Extra Space Storage LLC\n// https://www.iana.org/domains/root/db/extraspace.html\nextraspace\n\n//
+        fage : Fage International S.A.\n// https://www.iana.org/domains/root/db/fage.html\nfage\n\n//
+        fail : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/fail.html\nfail\n\n//
+        fairwinds : FairWinds Partners, LLC\n// https://www.iana.org/domains/root/db/fairwinds.html\nfairwinds\n\n//
+        faith : dot Faith Limited\n// https://www.iana.org/domains/root/db/faith.html\nfaith\n\n//
+        family : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/family.html\nfamily\n\n//
+        fan : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/fan.html\nfan\n\n//
+        fans : ZDNS International Limited\n// https://www.iana.org/domains/root/db/fans.html\nfans\n\n//
+        farm : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/farm.html\nfarm\n\n//
+        farmers : Farmers Insurance Exchange\n// https://www.iana.org/domains/root/db/farmers.html\nfarmers\n\n//
+        fashion : Registry Services, LLC\n// https://www.iana.org/domains/root/db/fashion.html\nfashion\n\n//
+        fast : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/fast.html\nfast\n\n//
+        fedex : Federal Express Corporation\n// https://www.iana.org/domains/root/db/fedex.html\nfedex\n\n//
+        feedback : Top Level Spectrum, Inc.\n// https://www.iana.org/domains/root/db/feedback.html\nfeedback\n\n//
+        ferrari : Fiat Chrysler Automobiles N.V.\n// https://www.iana.org/domains/root/db/ferrari.html\nferrari\n\n//
+        ferrero : Ferrero Trading Lux S.A.\n// https://www.iana.org/domains/root/db/ferrero.html\nferrero\n\n//
+        fidelity : Fidelity Brokerage Services LLC\n// https://www.iana.org/domains/root/db/fidelity.html\nfidelity\n\n//
+        fido : Rogers Communications Canada Inc.\n// https://www.iana.org/domains/root/db/fido.html\nfido\n\n//
+        film : Motion Picture Domain Registry Pty Ltd\n// https://www.iana.org/domains/root/db/film.html\nfilm\n\n//
+        final : N\xFAcleo de Informa\xE7\xE3o e Coordena\xE7\xE3o do Ponto BR - NIC.br\n//
+        https://www.iana.org/domains/root/db/final.html\nfinal\n\n// finance : Binky
+        Moon, LLC\n// https://www.iana.org/domains/root/db/finance.html\nfinance\n\n//
+        financial : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/financial.html\nfinancial\n\n//
+        fire : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/fire.html\nfire\n\n//
+        firestone : Bridgestone Licensing Services, Inc\n// https://www.iana.org/domains/root/db/firestone.html\nfirestone\n\n//
+        firmdale : Firmdale Holdings Limited\n// https://www.iana.org/domains/root/db/firmdale.html\nfirmdale\n\n//
+        fish : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/fish.html\nfish\n\n//
+        fishing : Registry Services, LLC\n// https://www.iana.org/domains/root/db/fishing.html\nfishing\n\n//
+        fit : Registry Services, LLC\n// https://www.iana.org/domains/root/db/fit.html\nfit\n\n//
+        fitness : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/fitness.html\nfitness\n\n//
+        flickr : Flickr, Inc.\n// https://www.iana.org/domains/root/db/flickr.html\nflickr\n\n//
+        flights : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/flights.html\nflights\n\n//
+        flir : FLIR Systems, Inc.\n// https://www.iana.org/domains/root/db/flir.html\nflir\n\n//
+        florist : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/florist.html\nflorist\n\n//
+        flowers : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/flowers.html\nflowers\n\n//
+        fly : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/fly.html\nfly\n\n//
+        foo : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/foo.html\nfoo\n\n//
+        food : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/food.html\nfood\n\n//
+        football : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/football.html\nfootball\n\n//
+        ford : Ford Motor Company\n// https://www.iana.org/domains/root/db/ford.html\nford\n\n//
+        forex : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/forex.html\nforex\n\n//
+        forsale : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/forsale.html\nforsale\n\n//
+        forum : Waterford Limited\n// https://www.iana.org/domains/root/db/forum.html\nforum\n\n//
+        foundation : Public Interest Registry\n// https://www.iana.org/domains/root/db/foundation.html\nfoundation\n\n//
+        fox : FOX Registry, LLC\n// https://www.iana.org/domains/root/db/fox.html\nfox\n\n//
+        free : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/free.html\nfree\n\n//
+        fresenius : Fresenius Immobilien-Verwaltungs-GmbH\n// https://www.iana.org/domains/root/db/fresenius.html\nfresenius\n\n//
+        frl : FRLregistry B.V.\n// https://www.iana.org/domains/root/db/frl.html\nfrl\n\n//
+        frogans : OP3FT\n// https://www.iana.org/domains/root/db/frogans.html\nfrogans\n\n//
+        frontier : Frontier Communications Corporation\n// https://www.iana.org/domains/root/db/frontier.html\nfrontier\n\n//
+        ftr : Frontier Communications Corporation\n// https://www.iana.org/domains/root/db/ftr.html\nftr\n\n//
+        fujitsu : Fujitsu Limited\n// https://www.iana.org/domains/root/db/fujitsu.html\nfujitsu\n\n//
+        fun : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/fun.html\nfun\n\n//
+        fund : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/fund.html\nfund\n\n//
+        furniture : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/furniture.html\nfurniture\n\n//
+        futbol : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/futbol.html\nfutbol\n\n//
+        fyi : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/fyi.html\nfyi\n\n//
+        gal : Asociaci\xF3n puntoGAL\n// https://www.iana.org/domains/root/db/gal.html\ngal\n\n//
+        gallery : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gallery.html\ngallery\n\n//
+        gallo : Gallo Vineyards, Inc.\n// https://www.iana.org/domains/root/db/gallo.html\ngallo\n\n//
+        gallup : Gallup, Inc.\n// https://www.iana.org/domains/root/db/gallup.html\ngallup\n\n//
+        game : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/game.html\ngame\n\n//
+        games : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/games.html\ngames\n\n//
+        gap : The Gap, Inc.\n// https://www.iana.org/domains/root/db/gap.html\ngap\n\n//
+        garden : Registry Services, LLC\n// https://www.iana.org/domains/root/db/garden.html\ngarden\n\n//
+        gay : Registry Services, LLC\n// https://www.iana.org/domains/root/db/gay.html\ngay\n\n//
+        gbiz : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/gbiz.html\ngbiz\n\n//
+        gdn : Joint Stock Company \"Navigation-information systems\"\n// https://www.iana.org/domains/root/db/gdn.html\ngdn\n\n//
+        gea : GEA Group Aktiengesellschaft\n// https://www.iana.org/domains/root/db/gea.html\ngea\n\n//
+        gent : Easyhost BV\n// https://www.iana.org/domains/root/db/gent.html\ngent\n\n//
+        genting : Resorts World Inc Pte. Ltd.\n// https://www.iana.org/domains/root/db/genting.html\ngenting\n\n//
+        george : Wal-Mart Stores, Inc.\n// https://www.iana.org/domains/root/db/george.html\ngeorge\n\n//
+        ggee : GMO Internet, Inc.\n// https://www.iana.org/domains/root/db/ggee.html\nggee\n\n//
+        gift : DotGift, LLC\n// https://www.iana.org/domains/root/db/gift.html\ngift\n\n//
+        gifts : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gifts.html\ngifts\n\n//
+        gives : Public Interest Registry\n// https://www.iana.org/domains/root/db/gives.html\ngives\n\n//
+        giving : Public Interest Registry\n// https://www.iana.org/domains/root/db/giving.html\ngiving\n\n//
+        glass : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/glass.html\nglass\n\n//
+        gle : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/gle.html\ngle\n\n//
+        global : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/global.html\nglobal\n\n//
+        globo : Globo Comunica\xE7\xE3o e Participa\xE7\xF5es S.A\n// https://www.iana.org/domains/root/db/globo.html\nglobo\n\n//
+        gmail : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/gmail.html\ngmail\n\n//
+        gmbh : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gmbh.html\ngmbh\n\n//
+        gmo : GMO Internet, Inc.\n// https://www.iana.org/domains/root/db/gmo.html\ngmo\n\n//
+        gmx : 1&1 Mail & Media GmbH\n// https://www.iana.org/domains/root/db/gmx.html\ngmx\n\n//
+        godaddy : Go Daddy East, LLC\n// https://www.iana.org/domains/root/db/godaddy.html\ngodaddy\n\n//
+        gold : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gold.html\ngold\n\n//
+        goldpoint : YODOBASHI CAMERA CO.,LTD.\n// https://www.iana.org/domains/root/db/goldpoint.html\ngoldpoint\n\n//
+        golf : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/golf.html\ngolf\n\n//
+        goodyear : The Goodyear Tire & Rubber Company\n// https://www.iana.org/domains/root/db/goodyear.html\ngoodyear\n\n//
+        goog : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/goog.html\ngoog\n\n//
+        google : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/google.html\ngoogle\n\n//
+        gop : Republican State Leadership Committee, Inc.\n// https://www.iana.org/domains/root/db/gop.html\ngop\n\n//
+        got : Jolly Host, LLC\n// https://www.iana.org/domains/root/db/got.html\ngot\n\n//
+        grainger : Grainger Registry Services, LLC\n// https://www.iana.org/domains/root/db/grainger.html\ngrainger\n\n//
+        graphics : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/graphics.html\ngraphics\n\n//
+        gratis : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gratis.html\ngratis\n\n//
+        green : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/green.html\ngreen\n\n//
+        gripe : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/gripe.html\ngripe\n\n//
+        grocery : Wal-Mart Stores, Inc.\n// https://www.iana.org/domains/root/db/grocery.html\ngrocery\n\n//
+        group : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/group.html\ngroup\n\n//
+        gucci : Guccio Gucci S.p.a.\n// https://www.iana.org/domains/root/db/gucci.html\ngucci\n\n//
+        guge : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/guge.html\nguge\n\n//
+        guide : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/guide.html\nguide\n\n//
+        guitars : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/guitars.html\nguitars\n\n//
+        guru : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/guru.html\nguru\n\n//
+        hair : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/hair.html\nhair\n\n//
+        hamburg : Hamburg Top-Level-Domain GmbH\n// https://www.iana.org/domains/root/db/hamburg.html\nhamburg\n\n//
+        hangout : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/hangout.html\nhangout\n\n//
+        haus : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/haus.html\nhaus\n\n//
+        hbo : HBO Registry Services, Inc.\n// https://www.iana.org/domains/root/db/hbo.html\nhbo\n\n//
+        hdfc : HDFC BANK LIMITED\n// https://www.iana.org/domains/root/db/hdfc.html\nhdfc\n\n//
+        hdfcbank : HDFC BANK LIMITED\n// https://www.iana.org/domains/root/db/hdfcbank.html\nhdfcbank\n\n//
+        health : Registry Services, LLC\n// https://www.iana.org/domains/root/db/health.html\nhealth\n\n//
+        healthcare : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/healthcare.html\nhealthcare\n\n//
+        help : Innovation service Limited\n// https://www.iana.org/domains/root/db/help.html\nhelp\n\n//
+        helsinki : City of Helsinki\n// https://www.iana.org/domains/root/db/helsinki.html\nhelsinki\n\n//
+        here : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/here.html\nhere\n\n//
+        hermes : HERMES INTERNATIONAL\n// https://www.iana.org/domains/root/db/hermes.html\nhermes\n\n//
+        hiphop : Dot Hip Hop, LLC\n// https://www.iana.org/domains/root/db/hiphop.html\nhiphop\n\n//
+        hisamitsu : Hisamitsu Pharmaceutical Co.,Inc.\n// https://www.iana.org/domains/root/db/hisamitsu.html\nhisamitsu\n\n//
+        hitachi : Hitachi, Ltd.\n// https://www.iana.org/domains/root/db/hitachi.html\nhitachi\n\n//
+        hiv : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/hiv.html\nhiv\n\n//
+        hkt : PCCW-HKT DataCom Services Limited\n// https://www.iana.org/domains/root/db/hkt.html\nhkt\n\n//
+        hockey : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/hockey.html\nhockey\n\n//
+        holdings : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/holdings.html\nholdings\n\n//
+        holiday : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/holiday.html\nholiday\n\n//
+        homedepot : Home Depot Product Authority, LLC\n// https://www.iana.org/domains/root/db/homedepot.html\nhomedepot\n\n//
+        homegoods : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/homegoods.html\nhomegoods\n\n//
+        homes : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/homes.html\nhomes\n\n//
+        homesense : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/homesense.html\nhomesense\n\n//
+        honda : Honda Motor Co., Ltd.\n// https://www.iana.org/domains/root/db/honda.html\nhonda\n\n//
+        horse : Registry Services, LLC\n// https://www.iana.org/domains/root/db/horse.html\nhorse\n\n//
+        hospital : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/hospital.html\nhospital\n\n//
+        host : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/host.html\nhost\n\n//
+        hosting : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/hosting.html\nhosting\n\n//
+        hot : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/hot.html\nhot\n\n//
+        hotel : HOTEL Top-Level-Domain S.a.r.l\n// https://www.iana.org/domains/root/db/hotel.html\nhotel\n\n//
+        hotels : Booking.com B.V.\n// https://www.iana.org/domains/root/db/hotels.html\nhotels\n\n//
+        hotmail : Microsoft Corporation\n// https://www.iana.org/domains/root/db/hotmail.html\nhotmail\n\n//
+        house : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/house.html\nhouse\n\n//
+        how : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/how.html\nhow\n\n//
+        hsbc : HSBC Global Services (UK) Limited\n// https://www.iana.org/domains/root/db/hsbc.html\nhsbc\n\n//
+        hughes : Hughes Satellite Systems Corporation\n// https://www.iana.org/domains/root/db/hughes.html\nhughes\n\n//
+        hyatt : Hyatt GTLD, L.L.C.\n// https://www.iana.org/domains/root/db/hyatt.html\nhyatt\n\n//
+        hyundai : Hyundai Motor Company\n// https://www.iana.org/domains/root/db/hyundai.html\nhyundai\n\n//
+        ibm : International Business Machines Corporation\n// https://www.iana.org/domains/root/db/ibm.html\nibm\n\n//
+        icbc : Industrial and Commercial Bank of China Limited\n// https://www.iana.org/domains/root/db/icbc.html\nicbc\n\n//
+        ice : IntercontinentalExchange, Inc.\n// https://www.iana.org/domains/root/db/ice.html\nice\n\n//
+        icu : ShortDot SA\n// https://www.iana.org/domains/root/db/icu.html\nicu\n\n//
+        ieee : IEEE Global LLC\n// https://www.iana.org/domains/root/db/ieee.html\nieee\n\n//
+        ifm : ifm electronic gmbh\n// https://www.iana.org/domains/root/db/ifm.html\nifm\n\n//
+        ikano : Ikano S.A.\n// https://www.iana.org/domains/root/db/ikano.html\nikano\n\n//
+        imamat : Fondation Aga Khan (Aga Khan Foundation)\n// https://www.iana.org/domains/root/db/imamat.html\nimamat\n\n//
+        imdb : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/imdb.html\nimdb\n\n//
+        immo : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/immo.html\nimmo\n\n//
+        immobilien : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/immobilien.html\nimmobilien\n\n//
+        inc : Intercap Registry Inc.\n// https://www.iana.org/domains/root/db/inc.html\ninc\n\n//
+        industries : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/industries.html\nindustries\n\n//
+        infiniti : NISSAN MOTOR CO., LTD.\n// https://www.iana.org/domains/root/db/infiniti.html\ninfiniti\n\n//
+        ing : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/ing.html\ning\n\n//
+        ink : Registry Services, LLC\n// https://www.iana.org/domains/root/db/ink.html\nink\n\n//
+        institute : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/institute.html\ninstitute\n\n//
+        insurance : fTLD Registry Services LLC\n// https://www.iana.org/domains/root/db/insurance.html\ninsurance\n\n//
+        insure : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/insure.html\ninsure\n\n//
+        international : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/international.html\ninternational\n\n//
+        intuit : Intuit Administrative Services, Inc.\n// https://www.iana.org/domains/root/db/intuit.html\nintuit\n\n//
+        investments : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/investments.html\ninvestments\n\n//
+        ipiranga : Ipiranga Produtos de Petroleo S.A.\n// https://www.iana.org/domains/root/db/ipiranga.html\nipiranga\n\n//
+        irish : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/irish.html\nirish\n\n//
+        ismaili : Fondation Aga Khan (Aga Khan Foundation)\n// https://www.iana.org/domains/root/db/ismaili.html\nismaili\n\n//
+        ist : Istanbul Metropolitan Municipality\n// https://www.iana.org/domains/root/db/ist.html\nist\n\n//
+        istanbul : Istanbul Metropolitan Municipality\n// https://www.iana.org/domains/root/db/istanbul.html\nistanbul\n\n//
+        itau : Itau Unibanco Holding S.A.\n// https://www.iana.org/domains/root/db/itau.html\nitau\n\n//
+        itv : ITV Services Limited\n// https://www.iana.org/domains/root/db/itv.html\nitv\n\n//
+        jaguar : Jaguar Land Rover Ltd\n// https://www.iana.org/domains/root/db/jaguar.html\njaguar\n\n//
+        java : Oracle Corporation\n// https://www.iana.org/domains/root/db/java.html\njava\n\n//
+        jcb : JCB Co., Ltd.\n// https://www.iana.org/domains/root/db/jcb.html\njcb\n\n//
+        jeep : FCA US LLC.\n// https://www.iana.org/domains/root/db/jeep.html\njeep\n\n//
+        jetzt : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/jetzt.html\njetzt\n\n//
+        jewelry : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/jewelry.html\njewelry\n\n//
+        jio : Reliance Industries Limited\n// https://www.iana.org/domains/root/db/jio.html\njio\n\n//
+        jll : Jones Lang LaSalle Incorporated\n// https://www.iana.org/domains/root/db/jll.html\njll\n\n//
+        jmp : Matrix IP LLC\n// https://www.iana.org/domains/root/db/jmp.html\njmp\n\n//
+        jnj : Johnson & Johnson Services, Inc.\n// https://www.iana.org/domains/root/db/jnj.html\njnj\n\n//
+        joburg : ZA Central Registry NPC trading as ZA Central Registry\n// https://www.iana.org/domains/root/db/joburg.html\njoburg\n\n//
+        jot : Jolly Host, LLC\n// https://www.iana.org/domains/root/db/jot.html\njot\n\n//
+        joy : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/joy.html\njoy\n\n//
+        jpmorgan : JPMorgan Chase Bank, National Association\n// https://www.iana.org/domains/root/db/jpmorgan.html\njpmorgan\n\n//
+        jprs : Japan Registry Services Co., Ltd.\n// https://www.iana.org/domains/root/db/jprs.html\njprs\n\n//
+        juegos : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/juegos.html\njuegos\n\n//
+        juniper : JUNIPER NETWORKS, INC.\n// https://www.iana.org/domains/root/db/juniper.html\njuniper\n\n//
+        kaufen : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/kaufen.html\nkaufen\n\n//
+        kddi : KDDI CORPORATION\n// https://www.iana.org/domains/root/db/kddi.html\nkddi\n\n//
+        kerryhotels : Kerry Trading Co. Limited\n// https://www.iana.org/domains/root/db/kerryhotels.html\nkerryhotels\n\n//
+        kerryproperties : Kerry Trading Co. Limited\n// https://www.iana.org/domains/root/db/kerryproperties.html\nkerryproperties\n\n//
+        kfh : Kuwait Finance House\n// https://www.iana.org/domains/root/db/kfh.html\nkfh\n\n//
+        kia : KIA MOTORS CORPORATION\n// https://www.iana.org/domains/root/db/kia.html\nkia\n\n//
+        kids : DotKids Foundation Limited\n// https://www.iana.org/domains/root/db/kids.html\nkids\n\n//
+        kim : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/kim.html\nkim\n\n//
+        kindle : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/kindle.html\nkindle\n\n//
+        kitchen : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/kitchen.html\nkitchen\n\n//
+        kiwi : DOT KIWI LIMITED\n// https://www.iana.org/domains/root/db/kiwi.html\nkiwi\n\n//
+        koeln : dotKoeln GmbH\n// https://www.iana.org/domains/root/db/koeln.html\nkoeln\n\n//
+        komatsu : Komatsu Ltd.\n// https://www.iana.org/domains/root/db/komatsu.html\nkomatsu\n\n//
+        kosher : Kosher Marketing Assets LLC\n// https://www.iana.org/domains/root/db/kosher.html\nkosher\n\n//
+        kpmg : KPMG International Cooperative (KPMG International Genossenschaft)\n//
+        https://www.iana.org/domains/root/db/kpmg.html\nkpmg\n\n// kpn : Koninklijke
+        KPN N.V.\n// https://www.iana.org/domains/root/db/kpn.html\nkpn\n\n// krd
+        : KRG Department of Information Technology\n// https://www.iana.org/domains/root/db/krd.html\nkrd\n\n//
+        kred : KredTLD Pty Ltd\n// https://www.iana.org/domains/root/db/kred.html\nkred\n\n//
+        kuokgroup : Kerry Trading Co. Limited\n// https://www.iana.org/domains/root/db/kuokgroup.html\nkuokgroup\n\n//
+        kyoto : Academic Institution: Kyoto Jyoho Gakuen\n// https://www.iana.org/domains/root/db/kyoto.html\nkyoto\n\n//
+        lacaixa : Fundaci\xF3n Bancaria Caixa d\u2019Estalvis i Pensions de Barcelona,
+        \u201Cla Caixa\u201D\n// https://www.iana.org/domains/root/db/lacaixa.html\nlacaixa\n\n//
+        lamborghini : Automobili Lamborghini S.p.A.\n// https://www.iana.org/domains/root/db/lamborghini.html\nlamborghini\n\n//
+        lamer : The Est\xE9e Lauder Companies Inc.\n// https://www.iana.org/domains/root/db/lamer.html\nlamer\n\n//
+        land : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/land.html\nland\n\n//
+        landrover : Jaguar Land Rover Ltd\n// https://www.iana.org/domains/root/db/landrover.html\nlandrover\n\n//
+        lanxess : LANXESS Corporation\n// https://www.iana.org/domains/root/db/lanxess.html\nlanxess\n\n//
+        lasalle : Jones Lang LaSalle Incorporated\n// https://www.iana.org/domains/root/db/lasalle.html\nlasalle\n\n//
+        lat : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/lat.html\nlat\n\n//
+        latino : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/latino.html\nlatino\n\n//
+        latrobe : La Trobe University\n// https://www.iana.org/domains/root/db/latrobe.html\nlatrobe\n\n//
+        law : Registry Services, LLC\n// https://www.iana.org/domains/root/db/law.html\nlaw\n\n//
+        lawyer : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/lawyer.html\nlawyer\n\n//
+        lds : IRI Domain Management, LLC\n// https://www.iana.org/domains/root/db/lds.html\nlds\n\n//
+        lease : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/lease.html\nlease\n\n//
+        leclerc : A.C.D. LEC Association des Centres Distributeurs Edouard Leclerc\n//
+        https://www.iana.org/domains/root/db/leclerc.html\nleclerc\n\n// lefrak :
+        LeFrak Organization, Inc.\n// https://www.iana.org/domains/root/db/lefrak.html\nlefrak\n\n//
+        legal : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/legal.html\nlegal\n\n//
+        lego : LEGO Juris A/S\n// https://www.iana.org/domains/root/db/lego.html\nlego\n\n//
+        lexus : TOYOTA MOTOR CORPORATION\n// https://www.iana.org/domains/root/db/lexus.html\nlexus\n\n//
+        lgbt : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/lgbt.html\nlgbt\n\n//
+        lidl : Schwarz Domains und Services GmbH & Co. KG\n// https://www.iana.org/domains/root/db/lidl.html\nlidl\n\n//
+        life : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/life.html\nlife\n\n//
+        lifeinsurance : American Council of Life Insurers\n// https://www.iana.org/domains/root/db/lifeinsurance.html\nlifeinsurance\n\n//
+        lifestyle : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/lifestyle.html\nlifestyle\n\n//
+        lighting : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/lighting.html\nlighting\n\n//
+        like : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/like.html\nlike\n\n//
+        lilly : Eli Lilly and Company\n// https://www.iana.org/domains/root/db/lilly.html\nlilly\n\n//
+        limited : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/limited.html\nlimited\n\n//
+        limo : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/limo.html\nlimo\n\n//
+        lincoln : Ford Motor Company\n// https://www.iana.org/domains/root/db/lincoln.html\nlincoln\n\n//
+        link : Nova Registry Ltd\n// https://www.iana.org/domains/root/db/link.html\nlink\n\n//
+        live : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/live.html\nlive\n\n//
+        living : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/living.html\nliving\n\n//
+        llc : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/llc.html\nllc\n\n//
+        llp : Intercap Registry Inc.\n// https://www.iana.org/domains/root/db/llp.html\nllp\n\n//
+        loan : dot Loan Limited\n// https://www.iana.org/domains/root/db/loan.html\nloan\n\n//
+        loans : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/loans.html\nloans\n\n//
+        locker : Orange Domains LLC\n// https://www.iana.org/domains/root/db/locker.html\nlocker\n\n//
+        locus : Locus Analytics LLC\n// https://www.iana.org/domains/root/db/locus.html\nlocus\n\n//
+        lol : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/lol.html\nlol\n\n//
+        london : Dot London Domains Limited\n// https://www.iana.org/domains/root/db/london.html\nlondon\n\n//
+        lotte : Lotte Holdings Co., Ltd.\n// https://www.iana.org/domains/root/db/lotte.html\nlotte\n\n//
+        lotto : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/lotto.html\nlotto\n\n//
+        love : Waterford Limited\n// https://www.iana.org/domains/root/db/love.html\nlove\n\n//
+        lpl : LPL Holdings, Inc.\n// https://www.iana.org/domains/root/db/lpl.html\nlpl\n\n//
+        lplfinancial : LPL Holdings, Inc.\n// https://www.iana.org/domains/root/db/lplfinancial.html\nlplfinancial\n\n//
+        ltd : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/ltd.html\nltd\n\n//
+        ltda : InterNetX, Corp\n// https://www.iana.org/domains/root/db/ltda.html\nltda\n\n//
+        lundbeck : H. Lundbeck A/S\n// https://www.iana.org/domains/root/db/lundbeck.html\nlundbeck\n\n//
+        luxe : Registry Services, LLC\n// https://www.iana.org/domains/root/db/luxe.html\nluxe\n\n//
+        luxury : Luxury Partners, LLC\n// https://www.iana.org/domains/root/db/luxury.html\nluxury\n\n//
+        madrid : Comunidad de Madrid\n// https://www.iana.org/domains/root/db/madrid.html\nmadrid\n\n//
+        maif : Mutuelle Assurance Instituteur France (MAIF)\n// https://www.iana.org/domains/root/db/maif.html\nmaif\n\n//
+        maison : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/maison.html\nmaison\n\n//
+        makeup : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/makeup.html\nmakeup\n\n//
+        man : MAN Truck & Bus SE\n// https://www.iana.org/domains/root/db/man.html\nman\n\n//
+        management : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/management.html\nmanagement\n\n//
+        mango : PUNTO FA S.L.\n// https://www.iana.org/domains/root/db/mango.html\nmango\n\n//
+        map : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/map.html\nmap\n\n//
+        market : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/market.html\nmarket\n\n//
+        marketing : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/marketing.html\nmarketing\n\n//
+        markets : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/markets.html\nmarkets\n\n//
+        marriott : Marriott Worldwide Corporation\n// https://www.iana.org/domains/root/db/marriott.html\nmarriott\n\n//
+        marshalls : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/marshalls.html\nmarshalls\n\n//
+        mattel : Mattel IT Services, Inc.\n// https://www.iana.org/domains/root/db/mattel.html\nmattel\n\n//
+        mba : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/mba.html\nmba\n\n//
+        mckinsey : McKinsey Holdings, Inc.\n// https://www.iana.org/domains/root/db/mckinsey.html\nmckinsey\n\n//
+        med : Medistry LLC\n// https://www.iana.org/domains/root/db/med.html\nmed\n\n//
+        media : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/media.html\nmedia\n\n//
+        meet : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/meet.html\nmeet\n\n//
+        melbourne : The Crown in right of the State of Victoria, represented by its
+        Department of State Development, Business and Innovation\n// https://www.iana.org/domains/root/db/melbourne.html\nmelbourne\n\n//
+        meme : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/meme.html\nmeme\n\n//
+        memorial : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/memorial.html\nmemorial\n\n//
+        men : Exclusive Registry Limited\n// https://www.iana.org/domains/root/db/men.html\nmen\n\n//
+        menu : Dot Menu Registry, LLC\n// https://www.iana.org/domains/root/db/menu.html\nmenu\n\n//
+        merck : Merck Registry Holdings, Inc.\n// https://www.iana.org/domains/root/db/merck.html\nmerck\n\n//
+        merckmsd : MSD Registry Holdings, Inc.\n// https://www.iana.org/domains/root/db/merckmsd.html\nmerckmsd\n\n//
+        miami : Registry Services, LLC\n// https://www.iana.org/domains/root/db/miami.html\nmiami\n\n//
+        microsoft : Microsoft Corporation\n// https://www.iana.org/domains/root/db/microsoft.html\nmicrosoft\n\n//
+        mini : Bayerische Motoren Werke Aktiengesellschaft\n// https://www.iana.org/domains/root/db/mini.html\nmini\n\n//
+        mint : Intuit Administrative Services, Inc.\n// https://www.iana.org/domains/root/db/mint.html\nmint\n\n//
+        mit : Massachusetts Institute of Technology\n// https://www.iana.org/domains/root/db/mit.html\nmit\n\n//
+        mitsubishi : Mitsubishi Corporation\n// https://www.iana.org/domains/root/db/mitsubishi.html\nmitsubishi\n\n//
+        mlb : MLB Advanced Media DH, LLC\n// https://www.iana.org/domains/root/db/mlb.html\nmlb\n\n//
+        mls : The Canadian Real Estate Association\n// https://www.iana.org/domains/root/db/mls.html\nmls\n\n//
+        mma : MMA IARD\n// https://www.iana.org/domains/root/db/mma.html\nmma\n\n//
+        mobile : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/mobile.html\nmobile\n\n//
+        moda : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/moda.html\nmoda\n\n//
+        moe : Interlink Systems Innovation Institute K.K.\n// https://www.iana.org/domains/root/db/moe.html\nmoe\n\n//
+        moi : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/moi.html\nmoi\n\n//
+        mom : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/mom.html\nmom\n\n//
+        monash : Monash University\n// https://www.iana.org/domains/root/db/monash.html\nmonash\n\n//
+        money : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/money.html\nmoney\n\n//
+        monster : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/monster.html\nmonster\n\n//
+        mormon : IRI Domain Management, LLC\n// https://www.iana.org/domains/root/db/mormon.html\nmormon\n\n//
+        mortgage : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/mortgage.html\nmortgage\n\n//
+        moscow : Foundation for Assistance for Internet Technologies and Infrastructure
+        Development (FAITID)\n// https://www.iana.org/domains/root/db/moscow.html\nmoscow\n\n//
+        moto : Motorola Trademark Holdings, LLC\n// https://www.iana.org/domains/root/db/moto.html\nmoto\n\n//
+        motorcycles : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/motorcycles.html\nmotorcycles\n\n//
+        mov : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/mov.html\nmov\n\n//
+        movie : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/movie.html\nmovie\n\n//
+        msd : MSD Registry Holdings, Inc.\n// https://www.iana.org/domains/root/db/msd.html\nmsd\n\n//
+        mtn : MTN Dubai Limited\n// https://www.iana.org/domains/root/db/mtn.html\nmtn\n\n//
+        mtr : MTR Corporation Limited\n// https://www.iana.org/domains/root/db/mtr.html\nmtr\n\n//
+        music : DotMusic Limited\n// https://www.iana.org/domains/root/db/music.html\nmusic\n\n//
+        nab : National Australia Bank Limited\n// https://www.iana.org/domains/root/db/nab.html\nnab\n\n//
+        nagoya : GMO Registry, Inc.\n// https://www.iana.org/domains/root/db/nagoya.html\nnagoya\n\n//
+        navy : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/navy.html\nnavy\n\n//
+        nba : NBA REGISTRY, LLC\n// https://www.iana.org/domains/root/db/nba.html\nnba\n\n//
+        nec : NEC Corporation\n// https://www.iana.org/domains/root/db/nec.html\nnec\n\n//
+        netbank : COMMONWEALTH BANK OF AUSTRALIA\n// https://www.iana.org/domains/root/db/netbank.html\nnetbank\n\n//
+        netflix : Netflix, Inc.\n// https://www.iana.org/domains/root/db/netflix.html\nnetflix\n\n//
+        network : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/network.html\nnetwork\n\n//
+        neustar : NeuStar, Inc.\n// https://www.iana.org/domains/root/db/neustar.html\nneustar\n\n//
+        new : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/new.html\nnew\n\n//
+        news : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/news.html\nnews\n\n//
+        next : Next plc\n// https://www.iana.org/domains/root/db/next.html\nnext\n\n//
+        nextdirect : Next plc\n// https://www.iana.org/domains/root/db/nextdirect.html\nnextdirect\n\n//
+        nexus : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/nexus.html\nnexus\n\n//
+        nfl : NFL Reg Ops LLC\n// https://www.iana.org/domains/root/db/nfl.html\nnfl\n\n//
+        ngo : Public Interest Registry\n// https://www.iana.org/domains/root/db/ngo.html\nngo\n\n//
+        nhk : Japan Broadcasting Corporation (NHK)\n// https://www.iana.org/domains/root/db/nhk.html\nnhk\n\n//
+        nico : DWANGO Co., Ltd.\n// https://www.iana.org/domains/root/db/nico.html\nnico\n\n//
+        nike : NIKE, Inc.\n// https://www.iana.org/domains/root/db/nike.html\nnike\n\n//
+        nikon : NIKON CORPORATION\n// https://www.iana.org/domains/root/db/nikon.html\nnikon\n\n//
+        ninja : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/ninja.html\nninja\n\n//
+        nissan : NISSAN MOTOR CO., LTD.\n// https://www.iana.org/domains/root/db/nissan.html\nnissan\n\n//
+        nissay : Nippon Life Insurance Company\n// https://www.iana.org/domains/root/db/nissay.html\nnissay\n\n//
+        nokia : Nokia Corporation\n// https://www.iana.org/domains/root/db/nokia.html\nnokia\n\n//
+        norton : Gen Digital Inc.\n// https://www.iana.org/domains/root/db/norton.html\nnorton\n\n//
+        now : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/now.html\nnow\n\n//
+        nowruz\n// https://www.iana.org/domains/root/db/nowruz.html\nnowruz\n\n//
+        nowtv : Starbucks (HK) Limited\n// https://www.iana.org/domains/root/db/nowtv.html\nnowtv\n\n//
+        nra : National Rifle Association of America\n// https://www.iana.org/domains/root/db/nra.html\nnra\n\n//
+        nrw : Minds + Machines GmbH\n// https://www.iana.org/domains/root/db/nrw.html\nnrw\n\n//
+        ntt : NIPPON TELEGRAPH AND TELEPHONE CORPORATION\n// https://www.iana.org/domains/root/db/ntt.html\nntt\n\n//
+        nyc : The City of New York by and through the New York City Department of
+        Information Technology & Telecommunications\n// https://www.iana.org/domains/root/db/nyc.html\nnyc\n\n//
+        obi : OBI Group Holding SE & Co. KGaA\n// https://www.iana.org/domains/root/db/obi.html\nobi\n\n//
+        observer : Fegistry, LLC\n// https://www.iana.org/domains/root/db/observer.html\nobserver\n\n//
+        office : Microsoft Corporation\n// https://www.iana.org/domains/root/db/office.html\noffice\n\n//
+        okinawa : BRregistry, Inc.\n// https://www.iana.org/domains/root/db/okinawa.html\nokinawa\n\n//
+        olayan : Competrol (Luxembourg) Sarl\n// https://www.iana.org/domains/root/db/olayan.html\nolayan\n\n//
+        olayangroup : Competrol (Luxembourg) Sarl\n// https://www.iana.org/domains/root/db/olayangroup.html\nolayangroup\n\n//
+        ollo : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/ollo.html\nollo\n\n//
+        omega : The Swatch Group Ltd\n// https://www.iana.org/domains/root/db/omega.html\nomega\n\n//
+        one : One.com A/S\n// https://www.iana.org/domains/root/db/one.html\none\n\n//
+        ong : Public Interest Registry\n// https://www.iana.org/domains/root/db/ong.html\nong\n\n//
+        onl : Jolly Host, LLC\n// https://www.iana.org/domains/root/db/onl.html\nonl\n\n//
+        online : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/online.html\nonline\n\n//
+        ooo : INFIBEAM AVENUES LIMITED\n// https://www.iana.org/domains/root/db/ooo.html\nooo\n\n//
+        open : American Express Travel Related Services Company, Inc.\n// https://www.iana.org/domains/root/db/open.html\nopen\n\n//
+        oracle : Oracle Corporation\n// https://www.iana.org/domains/root/db/oracle.html\noracle\n\n//
+        orange : Orange Brand Services Limited\n// https://www.iana.org/domains/root/db/orange.html\norange\n\n//
+        organic : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/organic.html\norganic\n\n//
+        origins : The Est\xE9e Lauder Companies Inc.\n// https://www.iana.org/domains/root/db/origins.html\norigins\n\n//
+        osaka : Osaka Registry Co., Ltd.\n// https://www.iana.org/domains/root/db/osaka.html\nosaka\n\n//
+        otsuka : Otsuka Holdings Co., Ltd.\n// https://www.iana.org/domains/root/db/otsuka.html\notsuka\n\n//
+        ott : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/ott.html\nott\n\n//
+        ovh : M\xE9diaBC\n// https://www.iana.org/domains/root/db/ovh.html\novh\n\n//
+        page : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/page.html\npage\n\n//
+        panasonic : Panasonic Holdings Corporation\n// https://www.iana.org/domains/root/db/panasonic.html\npanasonic\n\n//
+        paris : City of Paris\n// https://www.iana.org/domains/root/db/paris.html\nparis\n\n//
+        pars\n// https://www.iana.org/domains/root/db/pars.html\npars\n\n// partners
+        : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/partners.html\npartners\n\n//
+        parts : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/parts.html\nparts\n\n//
+        party : Blue Sky Registry Limited\n// https://www.iana.org/domains/root/db/party.html\nparty\n\n//
+        pay : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/pay.html\npay\n\n//
+        pccw : PCCW Enterprises Limited\n// https://www.iana.org/domains/root/db/pccw.html\npccw\n\n//
+        pet : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/pet.html\npet\n\n//
+        pfizer : Pfizer Inc.\n// https://www.iana.org/domains/root/db/pfizer.html\npfizer\n\n//
+        pharmacy : National Association of Boards of Pharmacy\n// https://www.iana.org/domains/root/db/pharmacy.html\npharmacy\n\n//
+        phd : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/phd.html\nphd\n\n//
+        philips : Koninklijke Philips N.V.\n// https://www.iana.org/domains/root/db/philips.html\nphilips\n\n//
+        phone : Dish DBS Corporation\n// https://www.iana.org/domains/root/db/phone.html\nphone\n\n//
+        photo : Registry Services, LLC\n// https://www.iana.org/domains/root/db/photo.html\nphoto\n\n//
+        photography : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/photography.html\nphotography\n\n//
+        photos : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/photos.html\nphotos\n\n//
+        physio : PhysBiz Pty Ltd\n// https://www.iana.org/domains/root/db/physio.html\nphysio\n\n//
+        pics : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/pics.html\npics\n\n//
+        pictet : Banque Pictet & Cie SA\n// https://www.iana.org/domains/root/db/pictet.html\npictet\n\n//
+        pictures : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/pictures.html\npictures\n\n//
+        pid : Top Level Spectrum, Inc.\n// https://www.iana.org/domains/root/db/pid.html\npid\n\n//
+        pin : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/pin.html\npin\n\n//
+        ping : Ping Registry Provider, Inc.\n// https://www.iana.org/domains/root/db/ping.html\nping\n\n//
+        pink : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/pink.html\npink\n\n//
+        pioneer : Pioneer Corporation\n// https://www.iana.org/domains/root/db/pioneer.html\npioneer\n\n//
+        pizza : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/pizza.html\npizza\n\n//
+        place : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/place.html\nplace\n\n//
+        play : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/play.html\nplay\n\n//
+        playstation : Sony Interactive Entertainment Inc.\n// https://www.iana.org/domains/root/db/playstation.html\nplaystation\n\n//
+        plumbing : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/plumbing.html\nplumbing\n\n//
+        plus : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/plus.html\nplus\n\n//
+        pnc : PNC Domain Co., LLC\n// https://www.iana.org/domains/root/db/pnc.html\npnc\n\n//
+        pohl : Deutsche Verm\xF6gensberatung Aktiengesellschaft DVAG\n// https://www.iana.org/domains/root/db/pohl.html\npohl\n\n//
+        poker : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/poker.html\npoker\n\n//
+        politie : Politie Nederland\n// https://www.iana.org/domains/root/db/politie.html\npolitie\n\n//
+        porn : ICM Registry PN LLC\n// https://www.iana.org/domains/root/db/porn.html\nporn\n\n//
+        praxi : Praxi S.p.A.\n// https://www.iana.org/domains/root/db/praxi.html\npraxi\n\n//
+        press : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/press.html\npress\n\n//
+        prime : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/prime.html\nprime\n\n//
+        prod : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/prod.html\nprod\n\n//
+        productions : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/productions.html\nproductions\n\n//
+        prof : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/prof.html\nprof\n\n//
+        progressive : Progressive Casualty Insurance Company\n// https://www.iana.org/domains/root/db/progressive.html\nprogressive\n\n//
+        promo : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/promo.html\npromo\n\n//
+        properties : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/properties.html\nproperties\n\n//
+        property : Digital Property Infrastructure Limited\n// https://www.iana.org/domains/root/db/property.html\nproperty\n\n//
+        protection : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/protection.html\nprotection\n\n//
+        pru : Prudential Financial, Inc.\n// https://www.iana.org/domains/root/db/pru.html\npru\n\n//
+        prudential : Prudential Financial, Inc.\n// https://www.iana.org/domains/root/db/prudential.html\nprudential\n\n//
+        pub : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/pub.html\npub\n\n//
+        pwc : PricewaterhouseCoopers LLP\n// https://www.iana.org/domains/root/db/pwc.html\npwc\n\n//
+        qpon : dotQPON LLC\n// https://www.iana.org/domains/root/db/qpon.html\nqpon\n\n//
+        quebec : PointQu\xE9bec Inc\n// https://www.iana.org/domains/root/db/quebec.html\nquebec\n\n//
+        quest : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/quest.html\nquest\n\n//
+        racing : Premier Registry Limited\n// https://www.iana.org/domains/root/db/racing.html\nracing\n\n//
+        radio : Digity, LLC\n// https://www.iana.org/domains/root/db/radio.html\nradio\n\n//
+        read : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/read.html\nread\n\n//
+        realestate : dotRealEstate LLC\n// https://www.iana.org/domains/root/db/realestate.html\nrealestate\n\n//
+        realtor : Real Estate Domains LLC\n// https://www.iana.org/domains/root/db/realtor.html\nrealtor\n\n//
+        realty : Waterford Limited\n// https://www.iana.org/domains/root/db/realty.html\nrealty\n\n//
+        recipes : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/recipes.html\nrecipes\n\n//
+        red : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/red.html\nred\n\n//
+        redumbrella : Travelers TLD, LLC\n// https://www.iana.org/domains/root/db/redumbrella.html\nredumbrella\n\n//
+        rehab : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/rehab.html\nrehab\n\n//
+        reise : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/reise.html\nreise\n\n//
+        reisen : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/reisen.html\nreisen\n\n//
+        reit : National Association of Real Estate Investment Trusts, Inc.\n// https://www.iana.org/domains/root/db/reit.html\nreit\n\n//
+        reliance : Reliance Industries Limited\n// https://www.iana.org/domains/root/db/reliance.html\nreliance\n\n//
+        ren : ZDNS International Limited\n// https://www.iana.org/domains/root/db/ren.html\nren\n\n//
+        rent : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/rent.html\nrent\n\n//
+        rentals : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/rentals.html\nrentals\n\n//
+        repair : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/repair.html\nrepair\n\n//
+        report : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/report.html\nreport\n\n//
+        republican : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/republican.html\nrepublican\n\n//
+        rest : Punto 2012 Sociedad Anonima Promotora de Inversion de Capital Variable\n//
+        https://www.iana.org/domains/root/db/rest.html\nrest\n\n// restaurant : Binky
+        Moon, LLC\n// https://www.iana.org/domains/root/db/restaurant.html\nrestaurant\n\n//
+        review : dot Review Limited\n// https://www.iana.org/domains/root/db/review.html\nreview\n\n//
+        reviews : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/reviews.html\nreviews\n\n//
+        rexroth : Robert Bosch GMBH\n// https://www.iana.org/domains/root/db/rexroth.html\nrexroth\n\n//
+        rich : iRegistry GmbH\n// https://www.iana.org/domains/root/db/rich.html\nrich\n\n//
+        richardli : Pacific Century Asset Management (HK) Limited\n// https://www.iana.org/domains/root/db/richardli.html\nrichardli\n\n//
+        ricoh : Ricoh Company, Ltd.\n// https://www.iana.org/domains/root/db/ricoh.html\nricoh\n\n//
+        ril : Reliance Industries Limited\n// https://www.iana.org/domains/root/db/ril.html\nril\n\n//
+        rio : Empresa Municipal de Inform\xE1tica SA - IPLANRIO\n// https://www.iana.org/domains/root/db/rio.html\nrio\n\n//
+        rip : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/rip.html\nrip\n\n//
+        rocks : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/rocks.html\nrocks\n\n//
+        rodeo : Registry Services, LLC\n// https://www.iana.org/domains/root/db/rodeo.html\nrodeo\n\n//
+        rogers : Rogers Communications Canada Inc.\n// https://www.iana.org/domains/root/db/rogers.html\nrogers\n\n//
+        room : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/room.html\nroom\n\n//
+        rsvp : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/rsvp.html\nrsvp\n\n//
+        rugby : World Rugby Strategic Developments Limited\n// https://www.iana.org/domains/root/db/rugby.html\nrugby\n\n//
+        ruhr : dotSaarland GmbH\n// https://www.iana.org/domains/root/db/ruhr.html\nruhr\n\n//
+        run : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/run.html\nrun\n\n//
+        rwe : RWE AG\n// https://www.iana.org/domains/root/db/rwe.html\nrwe\n\n//
+        ryukyu : BRregistry, Inc.\n// https://www.iana.org/domains/root/db/ryukyu.html\nryukyu\n\n//
+        saarland : dotSaarland GmbH\n// https://www.iana.org/domains/root/db/saarland.html\nsaarland\n\n//
+        safe : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/safe.html\nsafe\n\n//
+        safety : Jolly Host, LLC\n// https://www.iana.org/domains/root/db/safety.html\nsafety\n\n//
+        sakura : SAKURA Internet Inc.\n// https://www.iana.org/domains/root/db/sakura.html\nsakura\n\n//
+        sale : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/sale.html\nsale\n\n//
+        salon : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/salon.html\nsalon\n\n//
+        samsclub : Wal-Mart Stores, Inc.\n// https://www.iana.org/domains/root/db/samsclub.html\nsamsclub\n\n//
+        samsung : SAMSUNG SDS CO., LTD\n// https://www.iana.org/domains/root/db/samsung.html\nsamsung\n\n//
+        sandvik : Sandvik AB\n// https://www.iana.org/domains/root/db/sandvik.html\nsandvik\n\n//
+        sandvikcoromant : Sandvik AB\n// https://www.iana.org/domains/root/db/sandvikcoromant.html\nsandvikcoromant\n\n//
+        sanofi : Sanofi\n// https://www.iana.org/domains/root/db/sanofi.html\nsanofi\n\n//
+        sap : SAP AG\n// https://www.iana.org/domains/root/db/sap.html\nsap\n\n//
+        sarl : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/sarl.html\nsarl\n\n//
+        sas : Research IP LLC\n// https://www.iana.org/domains/root/db/sas.html\nsas\n\n//
+        save : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/save.html\nsave\n\n//
+        saxo : Saxo Bank A/S\n// https://www.iana.org/domains/root/db/saxo.html\nsaxo\n\n//
+        sbi : STATE BANK OF INDIA\n// https://www.iana.org/domains/root/db/sbi.html\nsbi\n\n//
+        sbs : ShortDot SA\n// https://www.iana.org/domains/root/db/sbs.html\nsbs\n\n//
+        scb : The Siam Commercial Bank Public Company Limited (\"SCB\")\n// https://www.iana.org/domains/root/db/scb.html\nscb\n\n//
+        schaeffler : Schaeffler Technologies AG & Co. KG\n// https://www.iana.org/domains/root/db/schaeffler.html\nschaeffler\n\n//
+        schmidt : SCHMIDT GROUPE S.A.S.\n// https://www.iana.org/domains/root/db/schmidt.html\nschmidt\n\n//
+        scholarships : Scholarships.com, LLC\n// https://www.iana.org/domains/root/db/scholarships.html\nscholarships\n\n//
+        school : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/school.html\nschool\n\n//
+        schule : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/schule.html\nschule\n\n//
+        schwarz : Schwarz Domains und Services GmbH & Co. KG\n// https://www.iana.org/domains/root/db/schwarz.html\nschwarz\n\n//
+        science : dot Science Limited\n// https://www.iana.org/domains/root/db/science.html\nscience\n\n//
+        scot : Dot Scot Registry Limited\n// https://www.iana.org/domains/root/db/scot.html\nscot\n\n//
+        search : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/search.html\nsearch\n\n//
+        seat : SEAT, S.A. (Sociedad Unipersonal)\n// https://www.iana.org/domains/root/db/seat.html\nseat\n\n//
+        secure : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/secure.html\nsecure\n\n//
+        security : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/security.html\nsecurity\n\n//
+        seek : Seek Limited\n// https://www.iana.org/domains/root/db/seek.html\nseek\n\n//
+        select : Registry Services, LLC\n// https://www.iana.org/domains/root/db/select.html\nselect\n\n//
+        sener : Sener Ingenier\xEDa y Sistemas, S.A.\n// https://www.iana.org/domains/root/db/sener.html\nsener\n\n//
+        services : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/services.html\nservices\n\n//
+        seven : Seven West Media Ltd\n// https://www.iana.org/domains/root/db/seven.html\nseven\n\n//
+        sew : SEW-EURODRIVE GmbH & Co KG\n// https://www.iana.org/domains/root/db/sew.html\nsew\n\n//
+        sex : ICM Registry SX LLC\n// https://www.iana.org/domains/root/db/sex.html\nsex\n\n//
+        sexy : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/sexy.html\nsexy\n\n//
+        sfr : Societe Francaise du Radiotelephone - SFR\n// https://www.iana.org/domains/root/db/sfr.html\nsfr\n\n//
+        shangrila : Shangri\u2010La International Hotel Management Limited\n// https://www.iana.org/domains/root/db/shangrila.html\nshangrila\n\n//
+        sharp : Sharp Corporation\n// https://www.iana.org/domains/root/db/sharp.html\nsharp\n\n//
+        shell : Shell Information Technology International Inc\n// https://www.iana.org/domains/root/db/shell.html\nshell\n\n//
+        shia\n// https://www.iana.org/domains/root/db/shia.html\nshia\n\n// shiksha
+        : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/shiksha.html\nshiksha\n\n//
+        shoes : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/shoes.html\nshoes\n\n//
+        shop : GMO Registry, Inc.\n// https://www.iana.org/domains/root/db/shop.html\nshop\n\n//
+        shopping : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/shopping.html\nshopping\n\n//
+        shouji : Beijing Qihu Keji Co., Ltd.\n// https://www.iana.org/domains/root/db/shouji.html\nshouji\n\n//
+        show : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/show.html\nshow\n\n//
+        silk : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/silk.html\nsilk\n\n//
+        sina : Sina Corporation\n// https://www.iana.org/domains/root/db/sina.html\nsina\n\n//
+        singles : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/singles.html\nsingles\n\n//
+        site : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/site.html\nsite\n\n//
+        ski : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/ski.html\nski\n\n//
+        skin : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/skin.html\nskin\n\n//
+        sky : Sky UK Limited\n// https://www.iana.org/domains/root/db/sky.html\nsky\n\n//
+        skype : Microsoft Corporation\n// https://www.iana.org/domains/root/db/skype.html\nskype\n\n//
+        sling : DISH Technologies L.L.C.\n// https://www.iana.org/domains/root/db/sling.html\nsling\n\n//
+        smart : Smart Communications, Inc. (SMART)\n// https://www.iana.org/domains/root/db/smart.html\nsmart\n\n//
+        smile : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/smile.html\nsmile\n\n//
+        sncf : Soci\xE9t\xE9 Nationale SNCF\n// https://www.iana.org/domains/root/db/sncf.html\nsncf\n\n//
+        soccer : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/soccer.html\nsoccer\n\n//
+        social : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/social.html\nsocial\n\n//
+        softbank : SoftBank Group Corp.\n// https://www.iana.org/domains/root/db/softbank.html\nsoftbank\n\n//
+        software : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/software.html\nsoftware\n\n//
+        sohu : Sohu.com Limited\n// https://www.iana.org/domains/root/db/sohu.html\nsohu\n\n//
+        solar : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/solar.html\nsolar\n\n//
+        solutions : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/solutions.html\nsolutions\n\n//
+        song : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/song.html\nsong\n\n//
+        sony : Sony Group Corporation\n// https://www.iana.org/domains/root/db/sony.html\nsony\n\n//
+        soy : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/soy.html\nsoy\n\n//
+        spa : Asia Spa and Wellness Promotion Council Limited\n// https://www.iana.org/domains/root/db/spa.html\nspa\n\n//
+        space : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/space.html\nspace\n\n//
+        sport : SportAccord\n// https://www.iana.org/domains/root/db/sport.html\nsport\n\n//
+        spot : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/spot.html\nspot\n\n//
+        srl : InterNetX, Corp\n// https://www.iana.org/domains/root/db/srl.html\nsrl\n\n//
+        stada : STADA Arzneimittel AG\n// https://www.iana.org/domains/root/db/stada.html\nstada\n\n//
+        staples : Staples, Inc.\n// https://www.iana.org/domains/root/db/staples.html\nstaples\n\n//
+        star : Star India Private Limited\n// https://www.iana.org/domains/root/db/star.html\nstar\n\n//
+        statebank : STATE BANK OF INDIA\n// https://www.iana.org/domains/root/db/statebank.html\nstatebank\n\n//
+        statefarm : State Farm Mutual Automobile Insurance Company\n// https://www.iana.org/domains/root/db/statefarm.html\nstatefarm\n\n//
+        stc : Saudi Telecom Company\n// https://www.iana.org/domains/root/db/stc.html\nstc\n\n//
+        stcgroup : Saudi Telecom Company\n// https://www.iana.org/domains/root/db/stcgroup.html\nstcgroup\n\n//
+        stockholm : Stockholms kommun\n// https://www.iana.org/domains/root/db/stockholm.html\nstockholm\n\n//
+        storage : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/storage.html\nstorage\n\n//
+        store : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/store.html\nstore\n\n//
+        stream : dot Stream Limited\n// https://www.iana.org/domains/root/db/stream.html\nstream\n\n//
+        studio : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/studio.html\nstudio\n\n//
+        study : Registry Services, LLC\n// https://www.iana.org/domains/root/db/study.html\nstudy\n\n//
+        style : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/style.html\nstyle\n\n//
+        sucks : Vox Populi Registry Ltd.\n// https://www.iana.org/domains/root/db/sucks.html\nsucks\n\n//
+        supplies : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/supplies.html\nsupplies\n\n//
+        supply : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/supply.html\nsupply\n\n//
+        support : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/support.html\nsupport\n\n//
+        surf : Registry Services, LLC\n// https://www.iana.org/domains/root/db/surf.html\nsurf\n\n//
+        surgery : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/surgery.html\nsurgery\n\n//
+        suzuki : SUZUKI MOTOR CORPORATION\n// https://www.iana.org/domains/root/db/suzuki.html\nsuzuki\n\n//
+        swatch : The Swatch Group Ltd\n// https://www.iana.org/domains/root/db/swatch.html\nswatch\n\n//
+        swiss : Swiss Confederation\n// https://www.iana.org/domains/root/db/swiss.html\nswiss\n\n//
+        sydney : State of New South Wales, Department of Premier and Cabinet\n// https://www.iana.org/domains/root/db/sydney.html\nsydney\n\n//
+        systems : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/systems.html\nsystems\n\n//
+        tab : Tabcorp Holdings Limited\n// https://www.iana.org/domains/root/db/tab.html\ntab\n\n//
+        taipei : Taipei City Government\n// https://www.iana.org/domains/root/db/taipei.html\ntaipei\n\n//
+        talk : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/talk.html\ntalk\n\n//
+        taobao : Alibaba Group Holding Limited\n// https://www.iana.org/domains/root/db/taobao.html\ntaobao\n\n//
+        target : Target Domain Holdings, LLC\n// https://www.iana.org/domains/root/db/target.html\ntarget\n\n//
+        tatamotors : Tata Motors Ltd\n// https://www.iana.org/domains/root/db/tatamotors.html\ntatamotors\n\n//
+        tatar : Limited Liability Company \"Coordination Center of Regional Domain
+        of Tatarstan Republic\"\n// https://www.iana.org/domains/root/db/tatar.html\ntatar\n\n//
+        tattoo : Registry Services, LLC\n// https://www.iana.org/domains/root/db/tattoo.html\ntattoo\n\n//
+        tax : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tax.html\ntax\n\n//
+        taxi : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/taxi.html\ntaxi\n\n//
+        tci\n// https://www.iana.org/domains/root/db/tci.html\ntci\n\n// tdk : TDK
+        Corporation\n// https://www.iana.org/domains/root/db/tdk.html\ntdk\n\n// team
+        : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/team.html\nteam\n\n//
+        tech : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/tech.html\ntech\n\n//
+        technology : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/technology.html\ntechnology\n\n//
+        temasek : Temasek Holdings (Private) Limited\n// https://www.iana.org/domains/root/db/temasek.html\ntemasek\n\n//
+        tennis : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tennis.html\ntennis\n\n//
+        teva : Teva Pharmaceutical Industries Limited\n// https://www.iana.org/domains/root/db/teva.html\nteva\n\n//
+        thd : Home Depot Product Authority, LLC\n// https://www.iana.org/domains/root/db/thd.html\nthd\n\n//
+        theater : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/theater.html\ntheater\n\n//
+        theatre : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/theatre.html\ntheatre\n\n//
+        tiaa : Teachers Insurance and Annuity Association of America\n// https://www.iana.org/domains/root/db/tiaa.html\ntiaa\n\n//
+        tickets : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/tickets.html\ntickets\n\n//
+        tienda : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tienda.html\ntienda\n\n//
+        tips : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tips.html\ntips\n\n//
+        tires : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tires.html\ntires\n\n//
+        tirol : punkt Tirol GmbH\n// https://www.iana.org/domains/root/db/tirol.html\ntirol\n\n//
+        tjmaxx : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/tjmaxx.html\ntjmaxx\n\n//
+        tjx : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/tjx.html\ntjx\n\n//
+        tkmaxx : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/tkmaxx.html\ntkmaxx\n\n//
+        tmall : Alibaba Group Holding Limited\n// https://www.iana.org/domains/root/db/tmall.html\ntmall\n\n//
+        today : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/today.html\ntoday\n\n//
+        tokyo : GMO Registry, Inc.\n// https://www.iana.org/domains/root/db/tokyo.html\ntokyo\n\n//
+        tools : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tools.html\ntools\n\n//
+        top : Hong Kong Zhongze International Limited\n// https://www.iana.org/domains/root/db/top.html\ntop\n\n//
+        toray : Toray Industries, Inc.\n// https://www.iana.org/domains/root/db/toray.html\ntoray\n\n//
+        toshiba : TOSHIBA Corporation\n// https://www.iana.org/domains/root/db/toshiba.html\ntoshiba\n\n//
+        total : TotalEnergies SE\n// https://www.iana.org/domains/root/db/total.html\ntotal\n\n//
+        tours : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/tours.html\ntours\n\n//
+        town : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/town.html\ntown\n\n//
+        toyota : TOYOTA MOTOR CORPORATION\n// https://www.iana.org/domains/root/db/toyota.html\ntoyota\n\n//
+        toys : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/toys.html\ntoys\n\n//
+        trade : Elite Registry Limited\n// https://www.iana.org/domains/root/db/trade.html\ntrade\n\n//
+        trading : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/trading.html\ntrading\n\n//
+        training : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/training.html\ntraining\n\n//
+        travel : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/travel.html\ntravel\n\n//
+        travelers : Travelers TLD, LLC\n// https://www.iana.org/domains/root/db/travelers.html\ntravelers\n\n//
+        travelersinsurance : Travelers TLD, LLC\n// https://www.iana.org/domains/root/db/travelersinsurance.html\ntravelersinsurance\n\n//
+        trust : Internet Naming Company LLC\n// https://www.iana.org/domains/root/db/trust.html\ntrust\n\n//
+        trv : Travelers TLD, LLC\n// https://www.iana.org/domains/root/db/trv.html\ntrv\n\n//
+        tube : Latin American Telecom LLC\n// https://www.iana.org/domains/root/db/tube.html\ntube\n\n//
+        tui : TUI AG\n// https://www.iana.org/domains/root/db/tui.html\ntui\n\n//
+        tunes : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/tunes.html\ntunes\n\n//
+        tushu : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/tushu.html\ntushu\n\n//
+        tvs : T V SUNDRAM IYENGAR  & SONS LIMITED\n// https://www.iana.org/domains/root/db/tvs.html\ntvs\n\n//
+        ubank : National Australia Bank Limited\n// https://www.iana.org/domains/root/db/ubank.html\nubank\n\n//
+        ubs : UBS AG\n// https://www.iana.org/domains/root/db/ubs.html\nubs\n\n//
+        unicom : China United Network Communications Corporation Limited\n// https://www.iana.org/domains/root/db/unicom.html\nunicom\n\n//
+        university : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/university.html\nuniversity\n\n//
+        uno : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/uno.html\nuno\n\n//
+        uol : UBN INTERNET LTDA.\n// https://www.iana.org/domains/root/db/uol.html\nuol\n\n//
+        ups : UPS Market Driver, Inc.\n// https://www.iana.org/domains/root/db/ups.html\nups\n\n//
+        vacations : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/vacations.html\nvacations\n\n//
+        vana : D3 Registry LLC\n// https://www.iana.org/domains/root/db/vana.html\nvana\n\n//
+        vanguard : The Vanguard Group, Inc.\n// https://www.iana.org/domains/root/db/vanguard.html\nvanguard\n\n//
+        vegas : Dot Vegas, Inc.\n// https://www.iana.org/domains/root/db/vegas.html\nvegas\n\n//
+        ventures : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/ventures.html\nventures\n\n//
+        verisign : VeriSign, Inc.\n// https://www.iana.org/domains/root/db/verisign.html\nverisign\n\n//
+        versicherung : tldbox GmbH\n// https://www.iana.org/domains/root/db/versicherung.html\nversicherung\n\n//
+        vet : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/vet.html\nvet\n\n//
+        viajes : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/viajes.html\nviajes\n\n//
+        video : Dog Beach, LLC\n// https://www.iana.org/domains/root/db/video.html\nvideo\n\n//
+        vig : VIENNA INSURANCE GROUP AG Wiener Versicherung Gruppe\n// https://www.iana.org/domains/root/db/vig.html\nvig\n\n//
+        viking : Viking River Cruises (Bermuda) Ltd.\n// https://www.iana.org/domains/root/db/viking.html\nviking\n\n//
+        villas : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/villas.html\nvillas\n\n//
+        vin : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/vin.html\nvin\n\n//
+        vip : Registry Services, LLC\n// https://www.iana.org/domains/root/db/vip.html\nvip\n\n//
+        virgin : Virgin Enterprises Limited\n// https://www.iana.org/domains/root/db/virgin.html\nvirgin\n\n//
+        visa : Visa Worldwide Pte. Limited\n// https://www.iana.org/domains/root/db/visa.html\nvisa\n\n//
+        vision : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/vision.html\nvision\n\n//
+        viva : Saudi Telecom Company\n// https://www.iana.org/domains/root/db/viva.html\nviva\n\n//
+        vivo : Telefonica Brasil S.A.\n// https://www.iana.org/domains/root/db/vivo.html\nvivo\n\n//
+        vlaanderen : DNS.be vzw\n// https://www.iana.org/domains/root/db/vlaanderen.html\nvlaanderen\n\n//
+        vodka : Registry Services, LLC\n// https://www.iana.org/domains/root/db/vodka.html\nvodka\n\n//
+        volvo : Volvo Holding Sverige Aktiebolag\n// https://www.iana.org/domains/root/db/volvo.html\nvolvo\n\n//
+        vote : Monolith Registry LLC\n// https://www.iana.org/domains/root/db/vote.html\nvote\n\n//
+        voting : Valuetainment Corp.\n// https://www.iana.org/domains/root/db/voting.html\nvoting\n\n//
+        voto : Monolith Registry LLC\n// https://www.iana.org/domains/root/db/voto.html\nvoto\n\n//
+        voyage : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/voyage.html\nvoyage\n\n//
+        wales : Nominet UK\n// https://www.iana.org/domains/root/db/wales.html\nwales\n\n//
+        walmart : Wal-Mart Stores, Inc.\n// https://www.iana.org/domains/root/db/walmart.html\nwalmart\n\n//
+        walter : Sandvik AB\n// https://www.iana.org/domains/root/db/walter.html\nwalter\n\n//
+        wang : Zodiac Wang Limited\n// https://www.iana.org/domains/root/db/wang.html\nwang\n\n//
+        wanggou : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/wanggou.html\nwanggou\n\n//
+        watch : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/watch.html\nwatch\n\n//
+        watches : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/watches.html\nwatches\n\n//
+        weather : The Weather Company, LLC\n// https://www.iana.org/domains/root/db/weather.html\nweather\n\n//
+        weatherchannel : The Weather Company, LLC\n// https://www.iana.org/domains/root/db/weatherchannel.html\nweatherchannel\n\n//
+        webcam : dot Webcam Limited\n// https://www.iana.org/domains/root/db/webcam.html\nwebcam\n\n//
+        weber : Saint-Gobain Weber SA\n// https://www.iana.org/domains/root/db/weber.html\nweber\n\n//
+        website : Radix Technologies Inc SEZC\n// https://www.iana.org/domains/root/db/website.html\nwebsite\n\n//
+        wed\n// https://www.iana.org/domains/root/db/wed.html\nwed\n\n// wedding :
+        Registry Services, LLC\n// https://www.iana.org/domains/root/db/wedding.html\nwedding\n\n//
+        weibo : Sina Corporation\n// https://www.iana.org/domains/root/db/weibo.html\nweibo\n\n//
+        weir : Weir Group IP Limited\n// https://www.iana.org/domains/root/db/weir.html\nweir\n\n//
+        whoswho : Who's Who Registry\n// https://www.iana.org/domains/root/db/whoswho.html\nwhoswho\n\n//
+        wien : domainworx Service & Management GmbH\n// https://www.iana.org/domains/root/db/wien.html\nwien\n\n//
+        wiki : Registry Services, LLC\n// https://www.iana.org/domains/root/db/wiki.html\nwiki\n\n//
+        williamhill : William Hill Organization Limited\n// https://www.iana.org/domains/root/db/williamhill.html\nwilliamhill\n\n//
+        win : First Registry Limited\n// https://www.iana.org/domains/root/db/win.html\nwin\n\n//
+        windows : Microsoft Corporation\n// https://www.iana.org/domains/root/db/windows.html\nwindows\n\n//
+        wine : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/wine.html\nwine\n\n//
+        winners : The TJX Companies, Inc.\n// https://www.iana.org/domains/root/db/winners.html\nwinners\n\n//
+        wme : William Morris Endeavor Entertainment, LLC\n// https://www.iana.org/domains/root/db/wme.html\nwme\n\n//
+        woodside : Woodside Petroleum Limited\n// https://www.iana.org/domains/root/db/woodside.html\nwoodside\n\n//
+        work : Registry Services, LLC\n// https://www.iana.org/domains/root/db/work.html\nwork\n\n//
+        works : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/works.html\nworks\n\n//
+        world : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/world.html\nworld\n\n//
+        wow : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/wow.html\nwow\n\n//
+        wtc : World Trade Centers Association, Inc.\n// https://www.iana.org/domains/root/db/wtc.html\nwtc\n\n//
+        wtf : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/wtf.html\nwtf\n\n//
+        xbox : Microsoft Corporation\n// https://www.iana.org/domains/root/db/xbox.html\nxbox\n\n//
+        xerox : Xerox DNHC LLC\n// https://www.iana.org/domains/root/db/xerox.html\nxerox\n\n//
+        xihuan : Beijing Qihu Keji Co., Ltd.\n// https://www.iana.org/domains/root/db/xihuan.html\nxihuan\n\n//
+        xin : Elegant Leader Limited\n// https://www.iana.org/domains/root/db/xin.html\nxin\n\n//
+        xn--11b4c3d : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--11b4c3d.html\n\u0915\u0949\u092E\n\n//
+        xn--1ck2e1b : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--1ck2e1b.html\n\u30BB\u30FC\u30EB\n\n//
+        xn--1qqw23a : Guangzhou YU Wei Information Technology Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--1qqw23a.html\n\u4F5B\u5C71\n\n//
+        xn--30rr7y : Excellent First Limited\n// https://www.iana.org/domains/root/db/xn--30rr7y.html\n\u6148\u5584\n\n//
+        xn--3bst00m : Eagle Horizon Limited\n// https://www.iana.org/domains/root/db/xn--3bst00m.html\n\u96C6\u56E2\n\n//
+        xn--3ds443g : Beijing TLD Registry Technology Limited\n// https://www.iana.org/domains/root/db/xn--3ds443g.html\n\u5728\u7EBF\n\n//
+        xn--3pxu8k : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--3pxu8k.html\n\u70B9\u770B\n\n//
+        xn--42c2d9a : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--42c2d9a.html\n\u0E04\u0E2D\u0E21\n\n//
+        xn--45q11c : Zodiac Gemini Ltd\n// https://www.iana.org/domains/root/db/xn--45q11c.html\n\u516B\u5366\n\n//
+        xn--4gbrim : Helium TLDs Ltd\n// https://www.iana.org/domains/root/db/xn--4gbrim.html\n\u0645\u0648\u0642\u0639\n\n//
+        xn--55qw42g : China Organizational Name Administration Center\n// https://www.iana.org/domains/root/db/xn--55qw42g.html\n\u516C\u76CA\n\n//
+        xn--55qx5d : China Internet Network Information Center (CNNIC)\n// https://www.iana.org/domains/root/db/xn--55qx5d.html\n\u516C\u53F8\n\n//
+        xn--5su34j936bgsg : Shangri\u2010La International Hotel Management Limited\n//
+        https://www.iana.org/domains/root/db/xn--5su34j936bgsg.html\n\u9999\u683C\u91CC\u62C9\n\n//
+        xn--5tzm5g : Global Website TLD Asia Limited\n// https://www.iana.org/domains/root/db/xn--5tzm5g.html\n\u7F51\u7AD9\n\n//
+        xn--6frz82g : Identity Digital Domains Limited\n// https://www.iana.org/domains/root/db/xn--6frz82g.html\n\u79FB\u52A8\n\n//
+        xn--6qq986b3xl : Tycoon Treasure Limited\n// https://www.iana.org/domains/root/db/xn--6qq986b3xl.html\n\u6211\u7231\u4F60\n\n//
+        xn--80adxhks : Foundation for Assistance for Internet Technologies and Infrastructure
+        Development (FAITID)\n// https://www.iana.org/domains/root/db/xn--80adxhks.html\n\u043C\u043E\u0441\u043A\u0432\u0430\n\n//
+        xn--80aqecdr1a : Pontificium Consilium de Comunicationibus Socialibus (PCCS)
+        (Pontifical Council for Social Communication)\n// https://www.iana.org/domains/root/db/xn--80aqecdr1a.html\n\u043A\u0430\u0442\u043E\u043B\u0438\u043A\n\n//
+        xn--80asehdb : CORE Association\n// https://www.iana.org/domains/root/db/xn--80asehdb.html\n\u043E\u043D\u043B\u0430\u0439\u043D\n\n//
+        xn--80aswg : CORE Association\n// https://www.iana.org/domains/root/db/xn--80aswg.html\n\u0441\u0430\u0439\u0442\n\n//
+        xn--8y0a063a : China United Network Communications Corporation Limited\n//
+        https://www.iana.org/domains/root/db/xn--8y0a063a.html\n\u8054\u901A\n\n//
+        xn--9dbq2a : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--9dbq2a.html\n\u05E7\u05D5\u05DD\n\n//
+        xn--9et52u : RISE VICTORY LIMITED\n// https://www.iana.org/domains/root/db/xn--9et52u.html\n\u65F6\u5C1A\n\n//
+        xn--9krt00a : Sina Corporation\n// https://www.iana.org/domains/root/db/xn--9krt00a.html\n\u5FAE\u535A\n\n//
+        xn--b4w605ferd : Temasek Holdings (Private) Limited\n// https://www.iana.org/domains/root/db/xn--b4w605ferd.html\n\u6DE1\u9A6C\u9521\n\n//
+        xn--bck1b9a5dre4c : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--bck1b9a5dre4c.html\n\u30D5\u30A1\u30C3\u30B7\u30E7\u30F3\n\n//
+        xn--c1avg : Public Interest Registry\n// https://www.iana.org/domains/root/db/xn--c1avg.html\n\u043E\u0440\u0433\n\n//
+        xn--c2br7g : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--c2br7g.html\n\u0928\u0947\u091F\n\n//
+        xn--cck2b3b : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--cck2b3b.html\n\u30B9\u30C8\u30A2\n\n//
+        xn--cckwcxetd : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--cckwcxetd.html\n\u30A2\u30DE\u30BE\u30F3\n\n//
+        xn--cg4bki : SAMSUNG SDS CO., LTD\n// https://www.iana.org/domains/root/db/xn--cg4bki.html\n\uC0BC\uC131\n\n//
+        xn--czr694b : Internet DotTrademark Organisation Limited\n// https://www.iana.org/domains/root/db/xn--czr694b.html\n\u5546\u6807\n\n//
+        xn--czrs0t : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/xn--czrs0t.html\n\u5546\u5E97\n\n//
+        xn--czru2d : Zodiac Aquarius Limited\n// https://www.iana.org/domains/root/db/xn--czru2d.html\n\u5546\u57CE\n\n//
+        xn--d1acj3b : The Foundation for Network Initiatives \u201CThe Smart Internet\u201D\n//
+        https://www.iana.org/domains/root/db/xn--d1acj3b.html\n\u0434\u0435\u0442\u0438\n\n//
+        xn--eckvdtc9d : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--eckvdtc9d.html\n\u30DD\u30A4\u30F3\u30C8\n\n//
+        xn--efvy88h : Guangzhou YU Wei Information Technology Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--efvy88h.html\n\u65B0\u95FB\n\n//
+        xn--fct429k : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--fct429k.html\n\u5BB6\u96FB\n\n//
+        xn--fhbei : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--fhbei.html\n\u0643\u0648\u0645\n\n//
+        xn--fiq228c5hs : Beijing TLD Registry Technology Limited\n// https://www.iana.org/domains/root/db/xn--fiq228c5hs.html\n\u4E2D\u6587\u7F51\n\n//
+        xn--fiq64b : CITIC Group Corporation\n// https://www.iana.org/domains/root/db/xn--fiq64b.html\n\u4E2D\u4FE1\n\n//
+        xn--fjq720a : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/xn--fjq720a.html\n\u5A31\u4E50\n\n//
+        xn--flw351e : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/xn--flw351e.html\n\u8C37\u6B4C\n\n//
+        xn--fzys8d69uvgm : PCCW Enterprises Limited\n// https://www.iana.org/domains/root/db/xn--fzys8d69uvgm.html\n\u96FB\u8A0A\u76C8\u79D1\n\n//
+        xn--g2xx48c : Nawang Heli(Xiamen) Network Service Co., LTD.\n// https://www.iana.org/domains/root/db/xn--g2xx48c.html\n\u8D2D\u7269\n\n//
+        xn--gckr3f0f : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--gckr3f0f.html\n\u30AF\u30E9\u30A6\u30C9\n\n//
+        xn--gk3at1e : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--gk3at1e.html\n\u901A\u8CA9\n\n//
+        xn--hxt814e : Zodiac Taurus Limited\n// https://www.iana.org/domains/root/db/xn--hxt814e.html\n\u7F51\u5E97\n\n//
+        xn--i1b6b1a6a2e : Public Interest Registry\n// https://www.iana.org/domains/root/db/xn--i1b6b1a6a2e.html\n\u0938\u0902\u0917\u0920\u0928\n\n//
+        xn--imr513n : Internet DotTrademark Organisation Limited\n// https://www.iana.org/domains/root/db/xn--imr513n.html\n\u9910\u5385\n\n//
+        xn--io0a7i : China Internet Network Information Center (CNNIC)\n// https://www.iana.org/domains/root/db/xn--io0a7i.html\n\u7F51\u7EDC\n\n//
+        xn--j1aef : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--j1aef.html\n\u043A\u043E\u043C\n\n//
+        xn--jlq480n2rg : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--jlq480n2rg.html\n\u4E9A\u9A6C\u900A\n\n//
+        xn--jvr189m : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--jvr189m.html\n\u98DF\u54C1\n\n//
+        xn--kcrx77d1x4a : Koninklijke Philips N.V.\n// https://www.iana.org/domains/root/db/xn--kcrx77d1x4a.html\n\u98DE\u5229\u6D66\n\n//
+        xn--kput3i : Beijing RITT-Net Technology Development Co., Ltd\n// https://www.iana.org/domains/root/db/xn--kput3i.html\n\u624B\u673A\n\n//
+        xn--mgba3a3ejt : Aramco Services Company\n// https://www.iana.org/domains/root/db/xn--mgba3a3ejt.html\n\u0627\u0631\u0627\u0645\u0643\u0648\n\n//
+        xn--mgba7c0bbn0a : Competrol (Luxembourg) Sarl\n// https://www.iana.org/domains/root/db/xn--mgba7c0bbn0a.html\n\u0627\u0644\u0639\u0644\u064A\u0627\u0646\n\n//
+        xn--mgbab2bd : CORE Association\n// https://www.iana.org/domains/root/db/xn--mgbab2bd.html\n\u0628\u0627\u0632\u0627\u0631\n\n//
+        xn--mgbca7dzdo : Abu Dhabi Systems and Information Centre\n// https://www.iana.org/domains/root/db/xn--mgbca7dzdo.html\n\u0627\u0628\u0648\u0638\u0628\u064A\n\n//
+        xn--mgbi4ecexp : Pontificium Consilium de Comunicationibus Socialibus (PCCS)
+        (Pontifical Council for Social Communication)\n// https://www.iana.org/domains/root/db/xn--mgbi4ecexp.html\n\u0643\u0627\u062B\u0648\u0644\u064A\u0643\n\n//
+        xn--mgbt3dhd\n// https://www.iana.org/domains/root/db/xn--mgbt3dhd.html\n\u0647\u0645\u0631\u0627\u0647\n\n//
+        xn--mk1bu44c : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--mk1bu44c.html\n\uB2F7\uCEF4\n\n//
+        xn--mxtq1m : Net-Chinese Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--mxtq1m.html\n\u653F\u5E9C\n\n//
+        xn--ngbc5azd : International Domain Registry Pty. Ltd.\n// https://www.iana.org/domains/root/db/xn--ngbc5azd.html\n\u0634\u0628\u0643\u0629\n\n//
+        xn--ngbe9e0a : Kuwait Finance House\n// https://www.iana.org/domains/root/db/xn--ngbe9e0a.html\n\u0628\u064A\u062A\u0643\n\n//
+        xn--ngbrx : League of Arab States\n// https://www.iana.org/domains/root/db/xn--ngbrx.html\n\u0639\u0631\u0628\n\n//
+        xn--nqv7f : Public Interest Registry\n// https://www.iana.org/domains/root/db/xn--nqv7f.html\n\u673A\u6784\n\n//
+        xn--nqv7fs00ema : Public Interest Registry\n// https://www.iana.org/domains/root/db/xn--nqv7fs00ema.html\n\u7EC4\u7EC7\u673A\u6784\n\n//
+        xn--nyqy26a : Stable Tone Limited\n// https://www.iana.org/domains/root/db/xn--nyqy26a.html\n\u5065\u5EB7\n\n//
+        xn--otu796d : Jiang Yu Liang Cai Technology Company Limited\n// https://www.iana.org/domains/root/db/xn--otu796d.html\n\u62DB\u8058\n\n//
+        xn--p1acf : Rusnames Limited\n// https://www.iana.org/domains/root/db/xn--p1acf.html\n\u0440\u0443\u0441\n\n//
+        xn--pssy2u : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--pssy2u.html\n\u5927\u62FF\n\n//
+        xn--q9jyb4c : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/xn--q9jyb4c.html\n\u307F\u3093\u306A\n\n//
+        xn--qcka1pmc : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/xn--qcka1pmc.html\n\u30B0\u30FC\u30B0\u30EB\n\n//
+        xn--rhqv96g : Stable Tone Limited\n// https://www.iana.org/domains/root/db/xn--rhqv96g.html\n\u4E16\u754C\n\n//
+        xn--rovu88b : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/xn--rovu88b.html\n\u66F8\u7C4D\n\n//
+        xn--ses554g : KNET Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--ses554g.html\n\u7F51\u5740\n\n//
+        xn--t60b56a : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--t60b56a.html\n\uB2F7\uB137\n\n//
+        xn--tckwe : VeriSign Sarl\n// https://www.iana.org/domains/root/db/xn--tckwe.html\n\u30B3\u30E0\n\n//
+        xn--tiq49xqyj : Pontificium Consilium de Comunicationibus Socialibus (PCCS)
+        (Pontifical Council for Social Communication)\n// https://www.iana.org/domains/root/db/xn--tiq49xqyj.html\n\u5929\u4E3B\u6559\n\n//
+        xn--unup4y : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/xn--unup4y.html\n\u6E38\u620F\n\n//
+        xn--vermgensberater-ctb : Deutsche Verm\xF6gensberatung Aktiengesellschaft
+        DVAG\n// https://www.iana.org/domains/root/db/xn--vermgensberater-ctb.html\nverm\xF6gensberater\n\n//
+        xn--vermgensberatung-pwb : Deutsche Verm\xF6gensberatung Aktiengesellschaft
+        DVAG\n// https://www.iana.org/domains/root/db/xn--vermgensberatung-pwb.html\nverm\xF6gensberatung\n\n//
+        xn--vhquv : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/xn--vhquv.html\n\u4F01\u4E1A\n\n//
+        xn--vuq861b : Beijing Tele-info Technology Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--vuq861b.html\n\u4FE1\u606F\n\n//
+        xn--w4r85el8fhu5dnra : Kerry Trading Co. Limited\n// https://www.iana.org/domains/root/db/xn--w4r85el8fhu5dnra.html\n\u5609\u91CC\u5927\u9152\u5E97\n\n//
+        xn--w4rs40l : Kerry Trading Co. Limited\n// https://www.iana.org/domains/root/db/xn--w4rs40l.html\n\u5609\u91CC\n\n//
+        xn--xhq521b : Guangzhou YU Wei Information Technology Co., Ltd.\n// https://www.iana.org/domains/root/db/xn--xhq521b.html\n\u5E7F\u4E1C\n\n//
+        xn--zfr164b : China Organizational Name Administration Center\n// https://www.iana.org/domains/root/db/xn--zfr164b.html\n\u653F\u52A1\n\n//
+        xyz : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/xyz.html\nxyz\n\n//
+        yachts : XYZ.COM LLC\n// https://www.iana.org/domains/root/db/yachts.html\nyachts\n\n//
+        yahoo : Yahoo Inc.\n// https://www.iana.org/domains/root/db/yahoo.html\nyahoo\n\n//
+        yamaxun : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/yamaxun.html\nyamaxun\n\n//
+        yandex : YANDEX, LLC\n// https://www.iana.org/domains/root/db/yandex.html\nyandex\n\n//
+        yodobashi : YODOBASHI CAMERA CO.,LTD.\n// https://www.iana.org/domains/root/db/yodobashi.html\nyodobashi\n\n//
+        yoga : Registry Services, LLC\n// https://www.iana.org/domains/root/db/yoga.html\nyoga\n\n//
+        yokohama : GMO Registry, Inc.\n// https://www.iana.org/domains/root/db/yokohama.html\nyokohama\n\n//
+        you : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/you.html\nyou\n\n//
+        youtube : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/youtube.html\nyoutube\n\n//
+        yun : Beijing Qihu Keji Co., Ltd.\n// https://www.iana.org/domains/root/db/yun.html\nyun\n\n//
+        zappos : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/zappos.html\nzappos\n\n//
+        zara : Industria de Dise\xF1o Textil, S.A. (INDITEX, S.A.)\n// https://www.iana.org/domains/root/db/zara.html\nzara\n\n//
+        zero : Amazon Registry Services, Inc.\n// https://www.iana.org/domains/root/db/zero.html\nzero\n\n//
+        zip : Charleston Road Registry Inc.\n// https://www.iana.org/domains/root/db/zip.html\nzip\n\n//
+        zone : Binky Moon, LLC\n// https://www.iana.org/domains/root/db/zone.html\nzone\n\n//
+        zuerich : Kanton Z\xFCrich (Canton of Zurich)\n// https://www.iana.org/domains/root/db/zuerich.html\nzuerich\n\n//
+        ===END ICANN DOMAINS===\n\n// ===BEGIN PRIVATE DOMAINS===\n\n// (Note: these
+        are in alphabetical order by company name)\n\n// .KRD : https://nic.krd\nco.krd\nedu.krd\n\n//
+        .pl domains (grandfathered)\nart.pl\ngliwice.pl\nkrakow.pl\npoznan.pl\nwroc.pl\nzakopane.pl\n\n//
+        1GB LLC : https://www.1gb.ua/\n// Submitted by 1GB LLC <noc@1gb.com.ua>\ncc.ua\ninf.ua\nltd.ua\n\n//
+        611 blockchain domain name system : https://sixone.one/\n611.to\n\n// A2 Hosting\n//
+        Submitted by Tyler Hall <sysadmin@a2hosting.com>\na2hosted.com\ncpserver.com\n\n//
+        Acorn Labs : https://acorn.io\n// Submitted by Craig Jellick <domains@acorn.io>\n*.on-acorn.io\n\n//
+        ActiveTrail : https://www.activetrail.biz/\n// Submitted by Ofer Kalaora <postmaster@activetrail.com>\nactivetrail.biz\n\n//
+        Adaptable.io : https://adaptable.io\n// Submitted by Mark Terrel <support@adaptable.io>\nadaptable.app\n\n//
+        addr.tools : https://addr.tools/\n// Submitted by Brian Shea <publicsuffixlist@addr.tools>\nmyaddr.dev\nmyaddr.io\ndyn.addr.tools\nmyaddr.tools\n\n//
+        Adobe : https://www.adobe.com/\n// Submitted by Ian Boston <boston@adobe.com>
+        and Lars Trieloff <trieloff@adobe.com>\nadobeaemcloud.com\n*.dev.adobeaemcloud.com\naem.live\nhlx.live\nadobeaemcloud.net\naem.network\naem.page\nhlx.page\naem.reviews\n\n//
+        Adobe Developer Platform : https://developer.adobe.com\n// Submitted by Jesse
+        MacFadyen<jessem@adobe.com>\nadobeio-static.net\nadobeioruntime.net\n\n//
+        Africa.com Web Solutions Ltd : https://registry.africa.com\n// Submitted by
+        Gavin Brown <gavin.brown@centralnic.com>\nafrica.com\n\n// AgentbaseAI Inc.
+        : https://assistant-ui.com\n// Submitted by Simon Farshid <security@assistant-ui.com>\n*.auiusercontent.com\n\n//
+        Agnat sp. z o.o. : https://domena.pl\n// Submitted by Przemyslaw Plewa <it-admin@domena.pl>\nbeep.pl\n\n//
+        Aiven : https://aiven.io/\n// Submitted by Aiven Security Team <security+appdomains@aiven.io>\naiven.app\naivencloud.com\n\n//
+        Akamai : https://www.akamai.com/\n// Submitted by Akamai Team <publicsuffixlist@akamai.com>\nakadns.net\nakamai.net\nakamai-staging.net\nakamaiedge.net\nakamaiedge-staging.net\nakamaihd.net\nakamaihd-staging.net\nakamaiorigin.net\nakamaiorigin-staging.net\nakamaized.net\nakamaized-staging.net\nedgekey.net\nedgekey-staging.net\nedgesuite.net\nedgesuite-staging.net\n\n//
+        alboto.ca : http://alboto.ca\n// Submitted by Anton Avramov <avramov@alboto.ca>\nbarsy.ca\n\n//
+        Alces Software Ltd : http://alces-software.com\n// Submitted by Mark J. Titorenko
+        <mark.titorenko@alces-software.com>\n*.compute.estate\n*.alces.network\n\n//
+        Alibaba Cloud API Gateway\n// Submitted by Alibaba Cloud Security <cloud_product_security_team@alibaba-inc.com>\nalibabacloudcs.com\nms.fun\nms.show\n\n//
+        all-inkl.com : https://all-inkl.com\n// Submitted by Werner Kaltofen <wk@all-inkl.com>\nkasserver.com\n\n//
+        Altervista : https://www.altervista.org\n// Submitted by Carlo Cannas <tech_staff@altervista.it>\naltervista.org\n\n//
+        alwaysdata : https://www.alwaysdata.com\n// Submitted by Cyril <admin@alwaysdata.com>\nalwaysdata.net\n\n//
+        Amaze Software : https://amaze.co\n// Submitted by Domain Admin <domainadmin@amaze.co>\nmyamaze.net\n\n//
+        Amazon : https://www.amazon.com/\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Subsections of Amazon/subsidiaries will appear until \"concludes\" tag\n\n//
+        Amazon API Gateway\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 6a4f5a95-8c7d-4077-a7af-9cf1abec0a53\nexecute-api.cn-north-1.amazonaws.com.cn\nexecute-api.cn-northwest-1.amazonaws.com.cn\nexecute-api.af-south-1.amazonaws.com\nexecute-api.ap-east-1.amazonaws.com\nexecute-api.ap-northeast-1.amazonaws.com\nexecute-api.ap-northeast-2.amazonaws.com\nexecute-api.ap-northeast-3.amazonaws.com\nexecute-api.ap-south-1.amazonaws.com\nexecute-api.ap-south-2.amazonaws.com\nexecute-api.ap-southeast-1.amazonaws.com\nexecute-api.ap-southeast-2.amazonaws.com\nexecute-api.ap-southeast-3.amazonaws.com\nexecute-api.ap-southeast-4.amazonaws.com\nexecute-api.ap-southeast-5.amazonaws.com\nexecute-api.ca-central-1.amazonaws.com\nexecute-api.ca-west-1.amazonaws.com\nexecute-api.eu-central-1.amazonaws.com\nexecute-api.eu-central-2.amazonaws.com\nexecute-api.eu-north-1.amazonaws.com\nexecute-api.eu-south-1.amazonaws.com\nexecute-api.eu-south-2.amazonaws.com\nexecute-api.eu-west-1.amazonaws.com\nexecute-api.eu-west-2.amazonaws.com\nexecute-api.eu-west-3.amazonaws.com\nexecute-api.il-central-1.amazonaws.com\nexecute-api.me-central-1.amazonaws.com\nexecute-api.me-south-1.amazonaws.com\nexecute-api.sa-east-1.amazonaws.com\nexecute-api.us-east-1.amazonaws.com\nexecute-api.us-east-2.amazonaws.com\nexecute-api.us-gov-east-1.amazonaws.com\nexecute-api.us-gov-west-1.amazonaws.com\nexecute-api.us-west-1.amazonaws.com\nexecute-api.us-west-2.amazonaws.com\n\n//
+        Amazon CloudFront\n// Submitted by Donavan Miller <donavanm@amazon.com>\n//
+        Reference: 54144616-fd49-4435-8535-19c6a601bdb3\ncloudfront.net\n\n// Amazon
+        Cognito\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n// Reference:
+        d7d4a954-976e-403e-a010-de9ed0cfbbd1\nauth.af-south-1.amazoncognito.com\nauth.ap-east-1.amazoncognito.com\nauth.ap-northeast-1.amazoncognito.com\nauth.ap-northeast-2.amazoncognito.com\nauth.ap-northeast-3.amazoncognito.com\nauth.ap-south-1.amazoncognito.com\nauth.ap-south-2.amazoncognito.com\nauth.ap-southeast-1.amazoncognito.com\nauth.ap-southeast-2.amazoncognito.com\nauth.ap-southeast-3.amazoncognito.com\nauth.ap-southeast-4.amazoncognito.com\nauth.ap-southeast-5.amazoncognito.com\nauth.ap-southeast-7.amazoncognito.com\nauth.ca-central-1.amazoncognito.com\nauth.ca-west-1.amazoncognito.com\nauth.eu-central-1.amazoncognito.com\nauth.eu-central-2.amazoncognito.com\nauth.eu-north-1.amazoncognito.com\nauth.eu-south-1.amazoncognito.com\nauth.eu-south-2.amazoncognito.com\nauth.eu-west-1.amazoncognito.com\nauth.eu-west-2.amazoncognito.com\nauth.eu-west-3.amazoncognito.com\nauth.il-central-1.amazoncognito.com\nauth.me-central-1.amazoncognito.com\nauth.me-south-1.amazoncognito.com\nauth.mx-central-1.amazoncognito.com\nauth.sa-east-1.amazoncognito.com\nauth.us-east-1.amazoncognito.com\nauth-fips.us-east-1.amazoncognito.com\nauth.us-east-2.amazoncognito.com\nauth-fips.us-east-2.amazoncognito.com\nauth-fips.us-gov-east-1.amazoncognito.com\nauth-fips.us-gov-west-1.amazoncognito.com\nauth.us-west-1.amazoncognito.com\nauth-fips.us-west-1.amazoncognito.com\nauth.us-west-2.amazoncognito.com\nauth-fips.us-west-2.amazoncognito.com\nauth.cognito-idp.eusc-de-east-1.on.amazonwebservices.eu\n\n//
+        Amazon EC2\n// Submitted by Luke Wells <psl-maintainers@amazon.com>\n// Reference:
+        4c38fa71-58ac-4768-99e5-689c1767e537\n*.compute.amazonaws.com.cn\n*.compute.amazonaws.com\n*.compute-1.amazonaws.com\nus-east-1.amazonaws.com\n\n//
+        Amazon EMR\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 82f43f9f-bbb8-400e-8349-854f5a62f20d\nemrappui-prod.cn-north-1.amazonaws.com.cn\nemrnotebooks-prod.cn-north-1.amazonaws.com.cn\nemrstudio-prod.cn-north-1.amazonaws.com.cn\nemrappui-prod.cn-northwest-1.amazonaws.com.cn\nemrnotebooks-prod.cn-northwest-1.amazonaws.com.cn\nemrstudio-prod.cn-northwest-1.amazonaws.com.cn\nemrappui-prod.af-south-1.amazonaws.com\nemrnotebooks-prod.af-south-1.amazonaws.com\nemrstudio-prod.af-south-1.amazonaws.com\nemrappui-prod.ap-east-1.amazonaws.com\nemrnotebooks-prod.ap-east-1.amazonaws.com\nemrstudio-prod.ap-east-1.amazonaws.com\nemrappui-prod.ap-northeast-1.amazonaws.com\nemrnotebooks-prod.ap-northeast-1.amazonaws.com\nemrstudio-prod.ap-northeast-1.amazonaws.com\nemrappui-prod.ap-northeast-2.amazonaws.com\nemrnotebooks-prod.ap-northeast-2.amazonaws.com\nemrstudio-prod.ap-northeast-2.amazonaws.com\nemrappui-prod.ap-northeast-3.amazonaws.com\nemrnotebooks-prod.ap-northeast-3.amazonaws.com\nemrstudio-prod.ap-northeast-3.amazonaws.com\nemrappui-prod.ap-south-1.amazonaws.com\nemrnotebooks-prod.ap-south-1.amazonaws.com\nemrstudio-prod.ap-south-1.amazonaws.com\nemrappui-prod.ap-south-2.amazonaws.com\nemrnotebooks-prod.ap-south-2.amazonaws.com\nemrstudio-prod.ap-south-2.amazonaws.com\nemrappui-prod.ap-southeast-1.amazonaws.com\nemrnotebooks-prod.ap-southeast-1.amazonaws.com\nemrstudio-prod.ap-southeast-1.amazonaws.com\nemrappui-prod.ap-southeast-2.amazonaws.com\nemrnotebooks-prod.ap-southeast-2.amazonaws.com\nemrstudio-prod.ap-southeast-2.amazonaws.com\nemrappui-prod.ap-southeast-3.amazonaws.com\nemrnotebooks-prod.ap-southeast-3.amazonaws.com\nemrstudio-prod.ap-southeast-3.amazonaws.com\nemrappui-prod.ap-southeast-4.amazonaws.com\nemrnotebooks-prod.ap-southeast-4.amazonaws.com\nemrstudio-prod.ap-southeast-4.amazonaws.com\nemrappui-prod.ca-central-1.amazonaws.com\nemrnotebooks-prod.ca-central-1.amazonaws.com\nemrstudio-prod.ca-central-1.amazonaws.com\nemrappui-prod.ca-west-1.amazonaws.com\nemrnotebooks-prod.ca-west-1.amazonaws.com\nemrstudio-prod.ca-west-1.amazonaws.com\nemrappui-prod.eu-central-1.amazonaws.com\nemrnotebooks-prod.eu-central-1.amazonaws.com\nemrstudio-prod.eu-central-1.amazonaws.com\nemrappui-prod.eu-central-2.amazonaws.com\nemrnotebooks-prod.eu-central-2.amazonaws.com\nemrstudio-prod.eu-central-2.amazonaws.com\nemrappui-prod.eu-north-1.amazonaws.com\nemrnotebooks-prod.eu-north-1.amazonaws.com\nemrstudio-prod.eu-north-1.amazonaws.com\nemrappui-prod.eu-south-1.amazonaws.com\nemrnotebooks-prod.eu-south-1.amazonaws.com\nemrstudio-prod.eu-south-1.amazonaws.com\nemrappui-prod.eu-south-2.amazonaws.com\nemrnotebooks-prod.eu-south-2.amazonaws.com\nemrstudio-prod.eu-south-2.amazonaws.com\nemrappui-prod.eu-west-1.amazonaws.com\nemrnotebooks-prod.eu-west-1.amazonaws.com\nemrstudio-prod.eu-west-1.amazonaws.com\nemrappui-prod.eu-west-2.amazonaws.com\nemrnotebooks-prod.eu-west-2.amazonaws.com\nemrstudio-prod.eu-west-2.amazonaws.com\nemrappui-prod.eu-west-3.amazonaws.com\nemrnotebooks-prod.eu-west-3.amazonaws.com\nemrstudio-prod.eu-west-3.amazonaws.com\nemrappui-prod.il-central-1.amazonaws.com\nemrnotebooks-prod.il-central-1.amazonaws.com\nemrstudio-prod.il-central-1.amazonaws.com\nemrappui-prod.me-central-1.amazonaws.com\nemrnotebooks-prod.me-central-1.amazonaws.com\nemrstudio-prod.me-central-1.amazonaws.com\nemrappui-prod.me-south-1.amazonaws.com\nemrnotebooks-prod.me-south-1.amazonaws.com\nemrstudio-prod.me-south-1.amazonaws.com\nemrappui-prod.sa-east-1.amazonaws.com\nemrnotebooks-prod.sa-east-1.amazonaws.com\nemrstudio-prod.sa-east-1.amazonaws.com\nemrappui-prod.us-east-1.amazonaws.com\nemrnotebooks-prod.us-east-1.amazonaws.com\nemrstudio-prod.us-east-1.amazonaws.com\nemrappui-prod.us-east-2.amazonaws.com\nemrnotebooks-prod.us-east-2.amazonaws.com\nemrstudio-prod.us-east-2.amazonaws.com\nemrappui-prod.us-gov-east-1.amazonaws.com\nemrnotebooks-prod.us-gov-east-1.amazonaws.com\nemrstudio-prod.us-gov-east-1.amazonaws.com\nemrappui-prod.us-gov-west-1.amazonaws.com\nemrnotebooks-prod.us-gov-west-1.amazonaws.com\nemrstudio-prod.us-gov-west-1.amazonaws.com\nemrappui-prod.us-west-1.amazonaws.com\nemrnotebooks-prod.us-west-1.amazonaws.com\nemrstudio-prod.us-west-1.amazonaws.com\nemrappui-prod.us-west-2.amazonaws.com\nemrnotebooks-prod.us-west-2.amazonaws.com\nemrstudio-prod.us-west-2.amazonaws.com\n\n//
+        Amazon Managed Workflows for Apache Airflow\n// Submitted by AWS Security
+        <psl-maintainers@amazon.com>\n// Reference: bfd043cc-2816-451d-894e-612c6b61a438\n*.airflow.af-south-1.on.aws\n*.airflow.ap-east-1.on.aws\n*.airflow.ap-northeast-1.on.aws\n*.airflow.ap-northeast-2.on.aws\n*.airflow.ap-northeast-3.on.aws\n*.airflow.ap-south-1.on.aws\n*.airflow.ap-south-2.on.aws\n*.airflow.ap-southeast-1.on.aws\n*.airflow.ap-southeast-2.on.aws\n*.airflow.ap-southeast-3.on.aws\n*.airflow.ap-southeast-4.on.aws\n*.airflow.ap-southeast-5.on.aws\n*.airflow.ca-central-1.on.aws\n*.airflow.ca-west-1.on.aws\n*.airflow.eu-central-1.on.aws\n*.airflow.eu-central-2.on.aws\n*.airflow.eu-north-1.on.aws\n*.airflow.eu-south-1.on.aws\n*.airflow.eu-south-2.on.aws\n*.airflow.eu-west-1.on.aws\n*.airflow.eu-west-2.on.aws\n*.airflow.eu-west-3.on.aws\n*.airflow.il-central-1.on.aws\n*.airflow.me-central-1.on.aws\n*.airflow.me-south-1.on.aws\n*.airflow.sa-east-1.on.aws\n*.airflow.us-east-1.on.aws\n*.airflow.us-east-2.on.aws\n*.airflow.us-west-1.on.aws\n*.airflow.us-west-2.on.aws\n*.cn-north-1.airflow.amazonaws.com.cn\n*.cn-northwest-1.airflow.amazonaws.com.cn\n*.airflow.cn-north-1.on.amazonwebservices.com.cn\n*.airflow.cn-northwest-1.on.amazonwebservices.com.cn\n*.af-south-1.airflow.amazonaws.com\n*.ap-east-1.airflow.amazonaws.com\n*.ap-northeast-1.airflow.amazonaws.com\n*.ap-northeast-2.airflow.amazonaws.com\n*.ap-northeast-3.airflow.amazonaws.com\n*.ap-south-1.airflow.amazonaws.com\n*.ap-south-2.airflow.amazonaws.com\n*.ap-southeast-1.airflow.amazonaws.com\n*.ap-southeast-2.airflow.amazonaws.com\n*.ap-southeast-3.airflow.amazonaws.com\n*.ap-southeast-4.airflow.amazonaws.com\n*.ap-southeast-5.airflow.amazonaws.com\n*.ap-southeast-7.airflow.amazonaws.com\n*.ca-central-1.airflow.amazonaws.com\n*.ca-west-1.airflow.amazonaws.com\n*.eu-central-1.airflow.amazonaws.com\n*.eu-central-2.airflow.amazonaws.com\n*.eu-north-1.airflow.amazonaws.com\n*.eu-south-1.airflow.amazonaws.com\n*.eu-south-2.airflow.amazonaws.com\n*.eu-west-1.airflow.amazonaws.com\n*.eu-west-2.airflow.amazonaws.com\n*.eu-west-3.airflow.amazonaws.com\n*.il-central-1.airflow.amazonaws.com\n*.me-central-1.airflow.amazonaws.com\n*.me-south-1.airflow.amazonaws.com\n*.sa-east-1.airflow.amazonaws.com\n*.us-east-1.airflow.amazonaws.com\n*.us-east-2.airflow.amazonaws.com\n*.us-west-1.airflow.amazonaws.com\n*.us-west-2.airflow.amazonaws.com\n\n//
+        Amazon Relational Database Service\n// Submitted by: AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 5aa87906-fd4f-4831-8727-4ffca6094159\n*.rds.cn-north-1.amazonaws.com.cn\n*.rds.cn-northwest-1.amazonaws.com.cn\n*.af-south-1.rds.amazonaws.com\n*.ap-east-1.rds.amazonaws.com\n*.ap-east-2.rds.amazonaws.com\n*.ap-northeast-1.rds.amazonaws.com\n*.ap-northeast-2.rds.amazonaws.com\n*.ap-northeast-3.rds.amazonaws.com\n*.ap-south-1.rds.amazonaws.com\n*.ap-south-2.rds.amazonaws.com\n*.ap-southeast-1.rds.amazonaws.com\n*.ap-southeast-2.rds.amazonaws.com\n*.ap-southeast-3.rds.amazonaws.com\n*.ap-southeast-4.rds.amazonaws.com\n*.ap-southeast-5.rds.amazonaws.com\n*.ap-southeast-6.rds.amazonaws.com\n*.ap-southeast-7.rds.amazonaws.com\n*.ca-central-1.rds.amazonaws.com\n*.ca-west-1.rds.amazonaws.com\n*.eu-central-1.rds.amazonaws.com\n*.eu-central-2.rds.amazonaws.com\n*.eu-west-1.rds.amazonaws.com\n*.eu-west-2.rds.amazonaws.com\n*.eu-west-3.rds.amazonaws.com\n*.il-central-1.rds.amazonaws.com\n*.me-central-1.rds.amazonaws.com\n*.me-south-1.rds.amazonaws.com\n*.mx-central-1.rds.amazonaws.com\n*.sa-east-1.rds.amazonaws.com\n*.us-east-1.rds.amazonaws.com\n*.us-east-2.rds.amazonaws.com\n*.us-gov-east-1.rds.amazonaws.com\n*.us-gov-west-1.rds.amazonaws.com\n*.us-northeast-1.rds.amazonaws.com\n*.us-west-1.rds.amazonaws.com\n*.us-west-2.rds.amazonaws.com\n\n//
+        Amazon S3\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n// Reference:
+        6f374c1c-1cc9-47de-8b2a-69ca56a3a3b6\ns3.dualstack.cn-north-1.amazonaws.com.cn\ns3-accesspoint.dualstack.cn-north-1.amazonaws.com.cn\ns3-website.dualstack.cn-north-1.amazonaws.com.cn\ns3.cn-north-1.amazonaws.com.cn\ns3-accesspoint.cn-north-1.amazonaws.com.cn\ns3-deprecated.cn-north-1.amazonaws.com.cn\ns3-object-lambda.cn-north-1.amazonaws.com.cn\ns3-website.cn-north-1.amazonaws.com.cn\ns3.dualstack.cn-northwest-1.amazonaws.com.cn\ns3-accesspoint.dualstack.cn-northwest-1.amazonaws.com.cn\ns3.cn-northwest-1.amazonaws.com.cn\ns3-accesspoint.cn-northwest-1.amazonaws.com.cn\ns3-object-lambda.cn-northwest-1.amazonaws.com.cn\ns3-website.cn-northwest-1.amazonaws.com.cn\ns3.dualstack.af-south-1.amazonaws.com\ns3-accesspoint.dualstack.af-south-1.amazonaws.com\ns3-website.dualstack.af-south-1.amazonaws.com\ns3.af-south-1.amazonaws.com\ns3-accesspoint.af-south-1.amazonaws.com\ns3-object-lambda.af-south-1.amazonaws.com\ns3-website.af-south-1.amazonaws.com\ns3.dualstack.ap-east-1.amazonaws.com\ns3-accesspoint.dualstack.ap-east-1.amazonaws.com\ns3.ap-east-1.amazonaws.com\ns3-accesspoint.ap-east-1.amazonaws.com\ns3-object-lambda.ap-east-1.amazonaws.com\ns3-website.ap-east-1.amazonaws.com\ns3.dualstack.ap-northeast-1.amazonaws.com\ns3-accesspoint.dualstack.ap-northeast-1.amazonaws.com\ns3-website.dualstack.ap-northeast-1.amazonaws.com\ns3.ap-northeast-1.amazonaws.com\ns3-accesspoint.ap-northeast-1.amazonaws.com\ns3-object-lambda.ap-northeast-1.amazonaws.com\ns3-website.ap-northeast-1.amazonaws.com\ns3.dualstack.ap-northeast-2.amazonaws.com\ns3-accesspoint.dualstack.ap-northeast-2.amazonaws.com\ns3-website.dualstack.ap-northeast-2.amazonaws.com\ns3.ap-northeast-2.amazonaws.com\ns3-accesspoint.ap-northeast-2.amazonaws.com\ns3-object-lambda.ap-northeast-2.amazonaws.com\ns3-website.ap-northeast-2.amazonaws.com\ns3.dualstack.ap-northeast-3.amazonaws.com\ns3-accesspoint.dualstack.ap-northeast-3.amazonaws.com\ns3-website.dualstack.ap-northeast-3.amazonaws.com\ns3.ap-northeast-3.amazonaws.com\ns3-accesspoint.ap-northeast-3.amazonaws.com\ns3-object-lambda.ap-northeast-3.amazonaws.com\ns3-website.ap-northeast-3.amazonaws.com\ns3.dualstack.ap-south-1.amazonaws.com\ns3-accesspoint.dualstack.ap-south-1.amazonaws.com\ns3-website.dualstack.ap-south-1.amazonaws.com\ns3.ap-south-1.amazonaws.com\ns3-accesspoint.ap-south-1.amazonaws.com\ns3-object-lambda.ap-south-1.amazonaws.com\ns3-website.ap-south-1.amazonaws.com\ns3.dualstack.ap-south-2.amazonaws.com\ns3-accesspoint.dualstack.ap-south-2.amazonaws.com\ns3-website.dualstack.ap-south-2.amazonaws.com\ns3.ap-south-2.amazonaws.com\ns3-accesspoint.ap-south-2.amazonaws.com\ns3-object-lambda.ap-south-2.amazonaws.com\ns3-website.ap-south-2.amazonaws.com\ns3.dualstack.ap-southeast-1.amazonaws.com\ns3-accesspoint.dualstack.ap-southeast-1.amazonaws.com\ns3-website.dualstack.ap-southeast-1.amazonaws.com\ns3.ap-southeast-1.amazonaws.com\ns3-accesspoint.ap-southeast-1.amazonaws.com\ns3-object-lambda.ap-southeast-1.amazonaws.com\ns3-website.ap-southeast-1.amazonaws.com\ns3.dualstack.ap-southeast-2.amazonaws.com\ns3-accesspoint.dualstack.ap-southeast-2.amazonaws.com\ns3-website.dualstack.ap-southeast-2.amazonaws.com\ns3.ap-southeast-2.amazonaws.com\ns3-accesspoint.ap-southeast-2.amazonaws.com\ns3-object-lambda.ap-southeast-2.amazonaws.com\ns3-website.ap-southeast-2.amazonaws.com\ns3.dualstack.ap-southeast-3.amazonaws.com\ns3-accesspoint.dualstack.ap-southeast-3.amazonaws.com\ns3-website.dualstack.ap-southeast-3.amazonaws.com\ns3.ap-southeast-3.amazonaws.com\ns3-accesspoint.ap-southeast-3.amazonaws.com\ns3-object-lambda.ap-southeast-3.amazonaws.com\ns3-website.ap-southeast-3.amazonaws.com\ns3.dualstack.ap-southeast-4.amazonaws.com\ns3-accesspoint.dualstack.ap-southeast-4.amazonaws.com\ns3-website.dualstack.ap-southeast-4.amazonaws.com\ns3.ap-southeast-4.amazonaws.com\ns3-accesspoint.ap-southeast-4.amazonaws.com\ns3-object-lambda.ap-southeast-4.amazonaws.com\ns3-website.ap-southeast-4.amazonaws.com\ns3.dualstack.ap-southeast-5.amazonaws.com\ns3-accesspoint.dualstack.ap-southeast-5.amazonaws.com\ns3-website.dualstack.ap-southeast-5.amazonaws.com\ns3.ap-southeast-5.amazonaws.com\ns3-accesspoint.ap-southeast-5.amazonaws.com\ns3-deprecated.ap-southeast-5.amazonaws.com\ns3-object-lambda.ap-southeast-5.amazonaws.com\ns3-website.ap-southeast-5.amazonaws.com\ns3.dualstack.ca-central-1.amazonaws.com\ns3-accesspoint.dualstack.ca-central-1.amazonaws.com\ns3-accesspoint-fips.dualstack.ca-central-1.amazonaws.com\ns3-fips.dualstack.ca-central-1.amazonaws.com\ns3-website.dualstack.ca-central-1.amazonaws.com\ns3.ca-central-1.amazonaws.com\ns3-accesspoint.ca-central-1.amazonaws.com\ns3-accesspoint-fips.ca-central-1.amazonaws.com\ns3-fips.ca-central-1.amazonaws.com\ns3-object-lambda.ca-central-1.amazonaws.com\ns3-website.ca-central-1.amazonaws.com\ns3.dualstack.ca-west-1.amazonaws.com\ns3-accesspoint.dualstack.ca-west-1.amazonaws.com\ns3-accesspoint-fips.dualstack.ca-west-1.amazonaws.com\ns3-fips.dualstack.ca-west-1.amazonaws.com\ns3-website.dualstack.ca-west-1.amazonaws.com\ns3.ca-west-1.amazonaws.com\ns3-accesspoint.ca-west-1.amazonaws.com\ns3-accesspoint-fips.ca-west-1.amazonaws.com\ns3-fips.ca-west-1.amazonaws.com\ns3-object-lambda.ca-west-1.amazonaws.com\ns3-website.ca-west-1.amazonaws.com\ns3.dualstack.eu-central-1.amazonaws.com\ns3-accesspoint.dualstack.eu-central-1.amazonaws.com\ns3-website.dualstack.eu-central-1.amazonaws.com\ns3.eu-central-1.amazonaws.com\ns3-accesspoint.eu-central-1.amazonaws.com\ns3-object-lambda.eu-central-1.amazonaws.com\ns3-website.eu-central-1.amazonaws.com\ns3.dualstack.eu-central-2.amazonaws.com\ns3-accesspoint.dualstack.eu-central-2.amazonaws.com\ns3-website.dualstack.eu-central-2.amazonaws.com\ns3.eu-central-2.amazonaws.com\ns3-accesspoint.eu-central-2.amazonaws.com\ns3-object-lambda.eu-central-2.amazonaws.com\ns3-website.eu-central-2.amazonaws.com\ns3.dualstack.eu-north-1.amazonaws.com\ns3-accesspoint.dualstack.eu-north-1.amazonaws.com\ns3.eu-north-1.amazonaws.com\ns3-accesspoint.eu-north-1.amazonaws.com\ns3-object-lambda.eu-north-1.amazonaws.com\ns3-website.eu-north-1.amazonaws.com\ns3.dualstack.eu-south-1.amazonaws.com\ns3-accesspoint.dualstack.eu-south-1.amazonaws.com\ns3-website.dualstack.eu-south-1.amazonaws.com\ns3.eu-south-1.amazonaws.com\ns3-accesspoint.eu-south-1.amazonaws.com\ns3-object-lambda.eu-south-1.amazonaws.com\ns3-website.eu-south-1.amazonaws.com\ns3.dualstack.eu-south-2.amazonaws.com\ns3-accesspoint.dualstack.eu-south-2.amazonaws.com\ns3-website.dualstack.eu-south-2.amazonaws.com\ns3.eu-south-2.amazonaws.com\ns3-accesspoint.eu-south-2.amazonaws.com\ns3-object-lambda.eu-south-2.amazonaws.com\ns3-website.eu-south-2.amazonaws.com\ns3.dualstack.eu-west-1.amazonaws.com\ns3-accesspoint.dualstack.eu-west-1.amazonaws.com\ns3-website.dualstack.eu-west-1.amazonaws.com\ns3.eu-west-1.amazonaws.com\ns3-accesspoint.eu-west-1.amazonaws.com\ns3-deprecated.eu-west-1.amazonaws.com\ns3-object-lambda.eu-west-1.amazonaws.com\ns3-website.eu-west-1.amazonaws.com\ns3.dualstack.eu-west-2.amazonaws.com\ns3-accesspoint.dualstack.eu-west-2.amazonaws.com\ns3.eu-west-2.amazonaws.com\ns3-accesspoint.eu-west-2.amazonaws.com\ns3-object-lambda.eu-west-2.amazonaws.com\ns3-website.eu-west-2.amazonaws.com\ns3.dualstack.eu-west-3.amazonaws.com\ns3-accesspoint.dualstack.eu-west-3.amazonaws.com\ns3-website.dualstack.eu-west-3.amazonaws.com\ns3.eu-west-3.amazonaws.com\ns3-accesspoint.eu-west-3.amazonaws.com\ns3-object-lambda.eu-west-3.amazonaws.com\ns3-website.eu-west-3.amazonaws.com\ns3.dualstack.il-central-1.amazonaws.com\ns3-accesspoint.dualstack.il-central-1.amazonaws.com\ns3-website.dualstack.il-central-1.amazonaws.com\ns3.il-central-1.amazonaws.com\ns3-accesspoint.il-central-1.amazonaws.com\ns3-object-lambda.il-central-1.amazonaws.com\ns3-website.il-central-1.amazonaws.com\ns3.dualstack.me-central-1.amazonaws.com\ns3-accesspoint.dualstack.me-central-1.amazonaws.com\ns3-website.dualstack.me-central-1.amazonaws.com\ns3.me-central-1.amazonaws.com\ns3-accesspoint.me-central-1.amazonaws.com\ns3-object-lambda.me-central-1.amazonaws.com\ns3-website.me-central-1.amazonaws.com\ns3.dualstack.me-south-1.amazonaws.com\ns3-accesspoint.dualstack.me-south-1.amazonaws.com\ns3.me-south-1.amazonaws.com\ns3-accesspoint.me-south-1.amazonaws.com\ns3-object-lambda.me-south-1.amazonaws.com\ns3-website.me-south-1.amazonaws.com\ns3.amazonaws.com\ns3-1.amazonaws.com\ns3-ap-east-1.amazonaws.com\ns3-ap-northeast-1.amazonaws.com\ns3-ap-northeast-2.amazonaws.com\ns3-ap-northeast-3.amazonaws.com\ns3-ap-south-1.amazonaws.com\ns3-ap-southeast-1.amazonaws.com\ns3-ap-southeast-2.amazonaws.com\ns3-ca-central-1.amazonaws.com\ns3-eu-central-1.amazonaws.com\ns3-eu-north-1.amazonaws.com\ns3-eu-west-1.amazonaws.com\ns3-eu-west-2.amazonaws.com\ns3-eu-west-3.amazonaws.com\ns3-external-1.amazonaws.com\ns3-fips-us-gov-east-1.amazonaws.com\ns3-fips-us-gov-west-1.amazonaws.com\nmrap.accesspoint.s3-global.amazonaws.com\ns3-me-south-1.amazonaws.com\ns3-sa-east-1.amazonaws.com\ns3-us-east-2.amazonaws.com\ns3-us-gov-east-1.amazonaws.com\ns3-us-gov-west-1.amazonaws.com\ns3-us-west-1.amazonaws.com\ns3-us-west-2.amazonaws.com\ns3-website-ap-northeast-1.amazonaws.com\ns3-website-ap-southeast-1.amazonaws.com\ns3-website-ap-southeast-2.amazonaws.com\ns3-website-eu-west-1.amazonaws.com\ns3-website-sa-east-1.amazonaws.com\ns3-website-us-east-1.amazonaws.com\ns3-website-us-gov-west-1.amazonaws.com\ns3-website-us-west-1.amazonaws.com\ns3-website-us-west-2.amazonaws.com\ns3.dualstack.sa-east-1.amazonaws.com\ns3-accesspoint.dualstack.sa-east-1.amazonaws.com\ns3-website.dualstack.sa-east-1.amazonaws.com\ns3.sa-east-1.amazonaws.com\ns3-accesspoint.sa-east-1.amazonaws.com\ns3-object-lambda.sa-east-1.amazonaws.com\ns3-website.sa-east-1.amazonaws.com\ns3.dualstack.us-east-1.amazonaws.com\ns3-accesspoint.dualstack.us-east-1.amazonaws.com\ns3-accesspoint-fips.dualstack.us-east-1.amazonaws.com\ns3-fips.dualstack.us-east-1.amazonaws.com\ns3-website.dualstack.us-east-1.amazonaws.com\ns3.us-east-1.amazonaws.com\ns3-accesspoint.us-east-1.amazonaws.com\ns3-accesspoint-fips.us-east-1.amazonaws.com\ns3-deprecated.us-east-1.amazonaws.com\ns3-fips.us-east-1.amazonaws.com\ns3-object-lambda.us-east-1.amazonaws.com\ns3-website.us-east-1.amazonaws.com\ns3.dualstack.us-east-2.amazonaws.com\ns3-accesspoint.dualstack.us-east-2.amazonaws.com\ns3-accesspoint-fips.dualstack.us-east-2.amazonaws.com\ns3-fips.dualstack.us-east-2.amazonaws.com\ns3-website.dualstack.us-east-2.amazonaws.com\ns3.us-east-2.amazonaws.com\ns3-accesspoint.us-east-2.amazonaws.com\ns3-accesspoint-fips.us-east-2.amazonaws.com\ns3-deprecated.us-east-2.amazonaws.com\ns3-fips.us-east-2.amazonaws.com\ns3-object-lambda.us-east-2.amazonaws.com\ns3-website.us-east-2.amazonaws.com\ns3.dualstack.us-gov-east-1.amazonaws.com\ns3-accesspoint.dualstack.us-gov-east-1.amazonaws.com\ns3-accesspoint-fips.dualstack.us-gov-east-1.amazonaws.com\ns3-fips.dualstack.us-gov-east-1.amazonaws.com\ns3-website.dualstack.us-gov-east-1.amazonaws.com\ns3.us-gov-east-1.amazonaws.com\ns3-accesspoint.us-gov-east-1.amazonaws.com\ns3-accesspoint-fips.us-gov-east-1.amazonaws.com\ns3-fips.us-gov-east-1.amazonaws.com\ns3-object-lambda.us-gov-east-1.amazonaws.com\ns3-website.us-gov-east-1.amazonaws.com\ns3.dualstack.us-gov-west-1.amazonaws.com\ns3-accesspoint.dualstack.us-gov-west-1.amazonaws.com\ns3-accesspoint-fips.dualstack.us-gov-west-1.amazonaws.com\ns3-fips.dualstack.us-gov-west-1.amazonaws.com\ns3-website.dualstack.us-gov-west-1.amazonaws.com\ns3.us-gov-west-1.amazonaws.com\ns3-accesspoint.us-gov-west-1.amazonaws.com\ns3-accesspoint-fips.us-gov-west-1.amazonaws.com\ns3-fips.us-gov-west-1.amazonaws.com\ns3-object-lambda.us-gov-west-1.amazonaws.com\ns3-website.us-gov-west-1.amazonaws.com\ns3.dualstack.us-west-1.amazonaws.com\ns3-accesspoint.dualstack.us-west-1.amazonaws.com\ns3-accesspoint-fips.dualstack.us-west-1.amazonaws.com\ns3-fips.dualstack.us-west-1.amazonaws.com\ns3-website.dualstack.us-west-1.amazonaws.com\ns3.us-west-1.amazonaws.com\ns3-accesspoint.us-west-1.amazonaws.com\ns3-accesspoint-fips.us-west-1.amazonaws.com\ns3-fips.us-west-1.amazonaws.com\ns3-object-lambda.us-west-1.amazonaws.com\ns3-website.us-west-1.amazonaws.com\ns3.dualstack.us-west-2.amazonaws.com\ns3-accesspoint.dualstack.us-west-2.amazonaws.com\ns3-accesspoint-fips.dualstack.us-west-2.amazonaws.com\ns3-fips.dualstack.us-west-2.amazonaws.com\ns3-website.dualstack.us-west-2.amazonaws.com\ns3.us-west-2.amazonaws.com\ns3-accesspoint.us-west-2.amazonaws.com\ns3-accesspoint-fips.us-west-2.amazonaws.com\ns3-deprecated.us-west-2.amazonaws.com\ns3-fips.us-west-2.amazonaws.com\ns3-object-lambda.us-west-2.amazonaws.com\ns3-website.us-west-2.amazonaws.com\n\n//
+        Amazon SageMaker Ground Truth\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 98dbfde4-7802-48c3-8751-b60f204e0d9c\nlabeling.ap-northeast-1.sagemaker.aws\nlabeling.ap-northeast-2.sagemaker.aws\nlabeling.ap-south-1.sagemaker.aws\nlabeling.ap-southeast-1.sagemaker.aws\nlabeling.ap-southeast-2.sagemaker.aws\nlabeling.ca-central-1.sagemaker.aws\nlabeling.eu-central-1.sagemaker.aws\nlabeling.eu-west-1.sagemaker.aws\nlabeling.eu-west-2.sagemaker.aws\nlabeling.us-east-1.sagemaker.aws\nlabeling.us-east-2.sagemaker.aws\nlabeling.us-west-2.sagemaker.aws\n\n//
+        Amazon SageMaker Notebook Instances\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: b5ea56df-669e-43cc-9537-14aa172f5dfc\nnotebook.af-south-1.sagemaker.aws\nnotebook.ap-east-1.sagemaker.aws\nnotebook.ap-northeast-1.sagemaker.aws\nnotebook.ap-northeast-2.sagemaker.aws\nnotebook.ap-northeast-3.sagemaker.aws\nnotebook.ap-south-1.sagemaker.aws\nnotebook.ap-south-2.sagemaker.aws\nnotebook.ap-southeast-1.sagemaker.aws\nnotebook.ap-southeast-2.sagemaker.aws\nnotebook.ap-southeast-3.sagemaker.aws\nnotebook.ap-southeast-4.sagemaker.aws\nnotebook.ca-central-1.sagemaker.aws\nnotebook-fips.ca-central-1.sagemaker.aws\nnotebook.ca-west-1.sagemaker.aws\nnotebook-fips.ca-west-1.sagemaker.aws\nnotebook.eu-central-1.sagemaker.aws\nnotebook.eu-central-2.sagemaker.aws\nnotebook.eu-north-1.sagemaker.aws\nnotebook.eu-south-1.sagemaker.aws\nnotebook.eu-south-2.sagemaker.aws\nnotebook.eu-west-1.sagemaker.aws\nnotebook.eu-west-2.sagemaker.aws\nnotebook.eu-west-3.sagemaker.aws\nnotebook.il-central-1.sagemaker.aws\nnotebook.me-central-1.sagemaker.aws\nnotebook.me-south-1.sagemaker.aws\nnotebook.sa-east-1.sagemaker.aws\nnotebook.us-east-1.sagemaker.aws\nnotebook-fips.us-east-1.sagemaker.aws\nnotebook.us-east-2.sagemaker.aws\nnotebook-fips.us-east-2.sagemaker.aws\nnotebook.us-gov-east-1.sagemaker.aws\nnotebook-fips.us-gov-east-1.sagemaker.aws\nnotebook.us-gov-west-1.sagemaker.aws\nnotebook-fips.us-gov-west-1.sagemaker.aws\nnotebook.us-west-1.sagemaker.aws\nnotebook-fips.us-west-1.sagemaker.aws\nnotebook.us-west-2.sagemaker.aws\nnotebook-fips.us-west-2.sagemaker.aws\nnotebook.cn-north-1.sagemaker.com.cn\nnotebook.cn-northwest-1.sagemaker.com.cn\n\n//
+        Amazon SageMaker Studio\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 475f237e-ab88-4041-9f41-7cfccdf66aeb\nstudio.af-south-1.sagemaker.aws\nstudio.ap-east-1.sagemaker.aws\nstudio.ap-northeast-1.sagemaker.aws\nstudio.ap-northeast-2.sagemaker.aws\nstudio.ap-northeast-3.sagemaker.aws\nstudio.ap-south-1.sagemaker.aws\nstudio.ap-southeast-1.sagemaker.aws\nstudio.ap-southeast-2.sagemaker.aws\nstudio.ap-southeast-3.sagemaker.aws\nstudio.ca-central-1.sagemaker.aws\nstudio.eu-central-1.sagemaker.aws\nstudio.eu-central-2.sagemaker.aws\nstudio.eu-north-1.sagemaker.aws\nstudio.eu-south-1.sagemaker.aws\nstudio.eu-south-2.sagemaker.aws\nstudio.eu-west-1.sagemaker.aws\nstudio.eu-west-2.sagemaker.aws\nstudio.eu-west-3.sagemaker.aws\nstudio.il-central-1.sagemaker.aws\nstudio.me-central-1.sagemaker.aws\nstudio.me-south-1.sagemaker.aws\nstudio.sa-east-1.sagemaker.aws\nstudio.us-east-1.sagemaker.aws\nstudio.us-east-2.sagemaker.aws\nstudio.us-gov-east-1.sagemaker.aws\nstudio-fips.us-gov-east-1.sagemaker.aws\nstudio.us-gov-west-1.sagemaker.aws\nstudio-fips.us-gov-west-1.sagemaker.aws\nstudio.us-west-1.sagemaker.aws\nstudio.us-west-2.sagemaker.aws\nstudio.cn-north-1.sagemaker.com.cn\nstudio.cn-northwest-1.sagemaker.com.cn\n\n//
+        Amazon SageMaker with MLflow\n// Submited by: AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: c19f92b3-a82a-452d-8189-831b572eea7e\n*.experiments.sagemaker.aws\n\n//
+        Analytics on AWS\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 955f9f40-a495-4e73-ae85-67b77ac9cadd\nanalytics-gateway.ap-northeast-1.amazonaws.com\nanalytics-gateway.ap-northeast-2.amazonaws.com\nanalytics-gateway.ap-south-1.amazonaws.com\nanalytics-gateway.ap-southeast-1.amazonaws.com\nanalytics-gateway.ap-southeast-2.amazonaws.com\nanalytics-gateway.eu-central-1.amazonaws.com\nanalytics-gateway.eu-west-1.amazonaws.com\nanalytics-gateway.us-east-1.amazonaws.com\nanalytics-gateway.us-east-2.amazonaws.com\nanalytics-gateway.us-west-2.amazonaws.com\n\n//
+        AWS Amplify\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: c35bed18-6f4f-424f-9298-5756f2f7d72b\namplifyapp.com\n\n// AWS
+        App Runner\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 6828c008-ba5d-442f-ade5-48da4e7c2316\n*.awsapprunner.com\n\n//
+        AWS Cloud9\n// Submitted by: AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 30717f72-4007-4f0f-8ed4-864c6f2efec9\nwebview-assets.aws-cloud9.af-south-1.amazonaws.com\nvfs.cloud9.af-south-1.amazonaws.com\nwebview-assets.cloud9.af-south-1.amazonaws.com\nwebview-assets.aws-cloud9.ap-east-1.amazonaws.com\nvfs.cloud9.ap-east-1.amazonaws.com\nwebview-assets.cloud9.ap-east-1.amazonaws.com\nwebview-assets.aws-cloud9.ap-northeast-1.amazonaws.com\nvfs.cloud9.ap-northeast-1.amazonaws.com\nwebview-assets.cloud9.ap-northeast-1.amazonaws.com\nwebview-assets.aws-cloud9.ap-northeast-2.amazonaws.com\nvfs.cloud9.ap-northeast-2.amazonaws.com\nwebview-assets.cloud9.ap-northeast-2.amazonaws.com\nwebview-assets.aws-cloud9.ap-northeast-3.amazonaws.com\nvfs.cloud9.ap-northeast-3.amazonaws.com\nwebview-assets.cloud9.ap-northeast-3.amazonaws.com\nwebview-assets.aws-cloud9.ap-south-1.amazonaws.com\nvfs.cloud9.ap-south-1.amazonaws.com\nwebview-assets.cloud9.ap-south-1.amazonaws.com\nwebview-assets.aws-cloud9.ap-southeast-1.amazonaws.com\nvfs.cloud9.ap-southeast-1.amazonaws.com\nwebview-assets.cloud9.ap-southeast-1.amazonaws.com\nwebview-assets.aws-cloud9.ap-southeast-2.amazonaws.com\nvfs.cloud9.ap-southeast-2.amazonaws.com\nwebview-assets.cloud9.ap-southeast-2.amazonaws.com\nwebview-assets.aws-cloud9.ca-central-1.amazonaws.com\nvfs.cloud9.ca-central-1.amazonaws.com\nwebview-assets.cloud9.ca-central-1.amazonaws.com\nwebview-assets.aws-cloud9.eu-central-1.amazonaws.com\nvfs.cloud9.eu-central-1.amazonaws.com\nwebview-assets.cloud9.eu-central-1.amazonaws.com\nwebview-assets.aws-cloud9.eu-north-1.amazonaws.com\nvfs.cloud9.eu-north-1.amazonaws.com\nwebview-assets.cloud9.eu-north-1.amazonaws.com\nwebview-assets.aws-cloud9.eu-south-1.amazonaws.com\nvfs.cloud9.eu-south-1.amazonaws.com\nwebview-assets.cloud9.eu-south-1.amazonaws.com\nwebview-assets.aws-cloud9.eu-west-1.amazonaws.com\nvfs.cloud9.eu-west-1.amazonaws.com\nwebview-assets.cloud9.eu-west-1.amazonaws.com\nwebview-assets.aws-cloud9.eu-west-2.amazonaws.com\nvfs.cloud9.eu-west-2.amazonaws.com\nwebview-assets.cloud9.eu-west-2.amazonaws.com\nwebview-assets.aws-cloud9.eu-west-3.amazonaws.com\nvfs.cloud9.eu-west-3.amazonaws.com\nwebview-assets.cloud9.eu-west-3.amazonaws.com\nwebview-assets.aws-cloud9.il-central-1.amazonaws.com\nvfs.cloud9.il-central-1.amazonaws.com\nwebview-assets.aws-cloud9.me-south-1.amazonaws.com\nvfs.cloud9.me-south-1.amazonaws.com\nwebview-assets.cloud9.me-south-1.amazonaws.com\nwebview-assets.aws-cloud9.sa-east-1.amazonaws.com\nvfs.cloud9.sa-east-1.amazonaws.com\nwebview-assets.cloud9.sa-east-1.amazonaws.com\nwebview-assets.aws-cloud9.us-east-1.amazonaws.com\nvfs.cloud9.us-east-1.amazonaws.com\nwebview-assets.cloud9.us-east-1.amazonaws.com\nwebview-assets.aws-cloud9.us-east-2.amazonaws.com\nvfs.cloud9.us-east-2.amazonaws.com\nwebview-assets.cloud9.us-east-2.amazonaws.com\nwebview-assets.aws-cloud9.us-west-1.amazonaws.com\nvfs.cloud9.us-west-1.amazonaws.com\nwebview-assets.cloud9.us-west-1.amazonaws.com\nwebview-assets.aws-cloud9.us-west-2.amazonaws.com\nvfs.cloud9.us-west-2.amazonaws.com\nwebview-assets.cloud9.us-west-2.amazonaws.com\n\n//
+        AWS Directory Service\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: a13203e8-42dc-4045-a0d2-2ee67bed1068\nawsapps.com\n\n// AWS Elastic
+        Beanstalk\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n// Reference:
+        e4e02a54-eaf9-4fe7-b662-39ccbc011a04\ncn-north-1.eb.amazonaws.com.cn\ncn-northwest-1.eb.amazonaws.com.cn\nelasticbeanstalk.com\naf-south-1.elasticbeanstalk.com\nap-east-1.elasticbeanstalk.com\nap-northeast-1.elasticbeanstalk.com\nap-northeast-2.elasticbeanstalk.com\nap-northeast-3.elasticbeanstalk.com\nap-south-1.elasticbeanstalk.com\nap-southeast-1.elasticbeanstalk.com\nap-southeast-2.elasticbeanstalk.com\nap-southeast-3.elasticbeanstalk.com\nap-southeast-5.elasticbeanstalk.com\nap-southeast-7.elasticbeanstalk.com\nca-central-1.elasticbeanstalk.com\neu-central-1.elasticbeanstalk.com\neu-north-1.elasticbeanstalk.com\neu-south-1.elasticbeanstalk.com\neu-south-2.elasticbeanstalk.com\neu-west-1.elasticbeanstalk.com\neu-west-2.elasticbeanstalk.com\neu-west-3.elasticbeanstalk.com\nil-central-1.elasticbeanstalk.com\nme-central-1.elasticbeanstalk.com\nme-south-1.elasticbeanstalk.com\nsa-east-1.elasticbeanstalk.com\nus-east-1.elasticbeanstalk.com\nus-east-2.elasticbeanstalk.com\nus-gov-east-1.elasticbeanstalk.com\nus-gov-west-1.elasticbeanstalk.com\nus-west-1.elasticbeanstalk.com\nus-west-2.elasticbeanstalk.com\n\n//
+        (AWS) Elastic Load Balancing\n// Submitted by Luke Wells <psl-maintainers@amazon.com>\n//
+        Reference: 12a3d528-1bac-4433-a359-a395867ffed2\n*.elb.amazonaws.com.cn\n*.elb.amazonaws.com\n\n//
+        AWS Global Accelerator\n// Submitted by Daniel Massaguer <psl-maintainers@amazon.com>\n//
+        Reference: d916759d-a08b-4241-b536-4db887383a6a\nawsglobalaccelerator.com\n\n//
+        AWS Lambda Function URLs\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 57df74ca-0820-46a5-89ea-0f0d0c4714b7\nlambda-url.af-south-1.on.aws\nlambda-url.ap-east-1.on.aws\nlambda-url.ap-northeast-1.on.aws\nlambda-url.ap-northeast-2.on.aws\nlambda-url.ap-northeast-3.on.aws\nlambda-url.ap-south-1.on.aws\nlambda-url.ap-southeast-1.on.aws\nlambda-url.ap-southeast-2.on.aws\nlambda-url.ap-southeast-3.on.aws\nlambda-url.ca-central-1.on.aws\nlambda-url.eu-central-1.on.aws\nlambda-url.eu-north-1.on.aws\nlambda-url.eu-south-1.on.aws\nlambda-url.eu-west-1.on.aws\nlambda-url.eu-west-2.on.aws\nlambda-url.eu-west-3.on.aws\nlambda-url.me-south-1.on.aws\nlambda-url.sa-east-1.on.aws\nlambda-url.us-east-1.on.aws\nlambda-url.us-east-2.on.aws\nlambda-url.us-west-1.on.aws\nlambda-url.us-west-2.on.aws\n\n//
+        AWS re:Post Private\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 83385945-225f-416e-9aa0-ad0632bfdcee\n*.private.repost.aws\n\n//
+        AWS Transfer Family web apps\n// Submitted by AWS Security <psl-maintainers@amazon.com>\n//
+        Reference: 9265cdd3-f017-42ab-98bb-08bf427d3fc9\ntransfer-webapp.af-south-1.on.aws\ntransfer-webapp.ap-east-1.on.aws\ntransfer-webapp.ap-northeast-1.on.aws\ntransfer-webapp.ap-northeast-2.on.aws\ntransfer-webapp.ap-northeast-3.on.aws\ntransfer-webapp.ap-south-1.on.aws\ntransfer-webapp.ap-south-2.on.aws\ntransfer-webapp.ap-southeast-1.on.aws\ntransfer-webapp.ap-southeast-2.on.aws\ntransfer-webapp.ap-southeast-3.on.aws\ntransfer-webapp.ap-southeast-4.on.aws\ntransfer-webapp.ap-southeast-5.on.aws\ntransfer-webapp.ap-southeast-7.on.aws\ntransfer-webapp.ca-central-1.on.aws\ntransfer-webapp.ca-west-1.on.aws\ntransfer-webapp.eu-central-1.on.aws\ntransfer-webapp.eu-central-2.on.aws\ntransfer-webapp.eu-north-1.on.aws\ntransfer-webapp.eu-south-1.on.aws\ntransfer-webapp.eu-south-2.on.aws\ntransfer-webapp.eu-west-1.on.aws\ntransfer-webapp.eu-west-2.on.aws\ntransfer-webapp.eu-west-3.on.aws\ntransfer-webapp.il-central-1.on.aws\ntransfer-webapp.me-central-1.on.aws\ntransfer-webapp.me-south-1.on.aws\ntransfer-webapp.mx-central-1.on.aws\ntransfer-webapp.sa-east-1.on.aws\ntransfer-webapp.us-east-1.on.aws\ntransfer-webapp.us-east-2.on.aws\ntransfer-webapp.us-gov-east-1.on.aws\ntransfer-webapp-fips.us-gov-east-1.on.aws\ntransfer-webapp.us-gov-west-1.on.aws\ntransfer-webapp-fips.us-gov-west-1.on.aws\ntransfer-webapp.us-west-1.on.aws\ntransfer-webapp.us-west-2.on.aws\ntransfer-webapp.cn-north-1.on.amazonwebservices.com.cn\ntransfer-webapp.cn-northwest-1.on.amazonwebservices.com.cn\n\n//
+        eero\n// Submitted by Yue Kang <eero-dynamic-dns@amazon.com>\n// Reference:
+        264afe70-f62c-4c02-8ab9-b5281ed24461\neero.online\neero-stage.online\n\n//
+        concludes Amazon\n\n// Anomaly : https://opencode.ai\n// Submitted by Dax
+        Raad <security@anoma.ly>\nopentunnel.xyz\n\n// Antagonist B.V. : https://www.antagonist.nl/\n//
+        Submitted by Sander Hoentjen <systeembeheer@antagonist.nl>\nantagonist.cloud\n\n//
+        Apigee : https://apigee.com/\n// Submitted by Apigee Security Team <security@apigee.com>\napigee.io\n\n//
+        Apis Networks : https://apisnetworks.com\n// Submitted by Matt Saladna <matt@apisnetworks.com>\npanel.dev\n\n//
+        Apphud : https://apphud.com\n// Submitted by Alexander Selivanov <alex@apphud.com>\nsiiites.com\n\n//
+        Apple : https://www.apple.com\n// Submitted by Apple DNS <dnscontact@apple.com>\nint.apple\n*.cloud.int.apple\n*.r.cloud.int.apple\n*.ap-north-1.r.cloud.int.apple\n*.ap-south-1.r.cloud.int.apple\n*.ap-south-2.r.cloud.int.apple\n*.eu-central-1.r.cloud.int.apple\n*.eu-north-1.r.cloud.int.apple\n*.us-central-1.r.cloud.int.apple\n*.us-central-2.r.cloud.int.apple\n*.us-east-1.r.cloud.int.apple\n*.us-east-2.r.cloud.int.apple\n*.us-west-1.r.cloud.int.apple\n*.us-west-2.r.cloud.int.apple\n*.us-west-3.r.cloud.int.apple\n\n//
+        Appspace : https://www.appspace.com\n// Submitted by Appspace Security Team
+        <security@appspace.com>\nappspacehosted.com\nappspaceusercontent.com\n\n//
+        Appudo UG (haftungsbeschr\xE4nkt) : https://www.appudo.com\n// Submitted by
+        Alexander Hochbaum <admin@appudo.com>\nappudo.net\n\n// Appwrite : https://appwrite.io\n//
+        Submitted by Steven Nguyen <security@appwrite.io>\nappwrite.global\nappwrite.network\n*.appwrite.run\n\n//
+        Aptible : https://www.aptible.com/\n// Submitted by Thomas Orozco <thomas@aptible.com>\non-aptible.com\n\n//
+        Aquapal : https://aquapal.net/\n// Submitted by Aki Ueno <admin@aquapal.net>\nf5.si\n\n//
+        ArvanCloud EdgeCompute\n// Submitted by ArvanCloud CDN <cdn@arvancloud.ir>\narvanedge.ir\n\n//
+        ASEINet : https://www.aseinet.com/\n// Submitted by Asei SEKIGUCHI <mail@aseinet.com>\nuser.aseinet.ne.jp\ngv.vc\nd.gv.vc\n\n//
+        Asociaci\xF3n Amigos de la Inform\xE1tica \"Euskalamiga\" : http://encounter.eus/\n//
+        Submitted by Hector Martin <marcan@euskalencounter.org>\nuser.party.eus\n\n//
+        Association potager.org : https://potager.org/\n// Submitted by Lunar <jardiniers@potager.org>\npimienta.org\npoivron.org\npotager.org\nsweetpepper.org\n\n//
+        ASUSTOR Inc. : http://www.asustor.com\n// Submitted by Vincent Tseng <vincenttseng@asustor.com>\nmyasustor.com\n\n//
+        Atlassian : https://atlassian.com\n// Submitted by Sam Smyth <devloop@atlassian.com>\ncdn.prod.atlassian-dev.net\n\n//
+        AVM : https://avm.de\n// Submitted by Andreas Weise <a.weise@avm.de>\nmyfritz.link\nmyfritz.net\n\n//
+        AW AdvisorWebsites.com Software Inc : https://advisorwebsites.com\n// Submitted
+        by James Kennedy <domains@advisorwebsites.com>\n*.awdev.ca\n*.advisor.ws\n\n//
+        AZ.pl sp. z.o.o : https://az.pl\n// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>\necommerce-shop.pl\n\n//
+        b-data GmbH : https://www.b-data.io\n// Submitted by Olivier Benz <olivier.benz@b-data.ch>\nb-data.io\n\n//
+        Balena : https://www.balena.io\n// Submitted by Petros Angelatos <petrosagg@balena.io>\nbalena-devices.com\n\n//
+        BASE, Inc. : https://binc.jp\n// Submitted by Yuya NAGASAWA <public-suffix-list@binc.jp>\nbase.ec\nofficial.ec\nbuyshop.jp\nfashionstore.jp\nhandcrafted.jp\nkawaiishop.jp\nsupersale.jp\ntheshop.jp\nshopselect.net\nbase.shop\n\n//
+        BeagleBoard.org Foundation : https://beagleboard.org\n// Submitted by Jason
+        Kridner <jkridner@beagleboard.org>\nbeagleboard.io\n\n// Bear Blog : https://bearblog.dev\n//
+        Submitted by Herman Martinus <admin@bearblog.dev>\nbearblog.dev\n\n// Beget
+        LLC : https://beget.com\n// Submitted by Lev Nekrasov & Nikita Radchenko <admin@beget.com>\n*.beget.app\n*.begetcdn.cloud\n\n//
+        Besties : https://besties.house\n// Submitted by Hazel Cora <hazy@besties.house>\npages.gay\n\n//
+        BinaryLane : http://www.binarylane.com\n// Submitted by Nathan O'Sullivan
+        <nathan@mammoth.com.au>\nbnr.la\n\n// Bitbucket : http://bitbucket.org\n//
+        Submitted by Andy Ortlieb <aortlieb@atlassian.com>\nbitbucket.io\n\n// Blackbaud,
+        Inc. : https://www.blackbaud.com\n// Submitted by Paul Crowder <paul.crowder@blackbaud.com>\nblackbaudcdn.net\n\n//
+        Blatech : http://www.blatech.net\n// Submitted by Luke Bratch <luke@bratch.co.uk>\nof.je\n\n//
+        Block, Inc. : https://block.xyz\n// Submitted by Jonathan Boice <security@block.xyz>\nsquare.site\n\n//
+        Blue Bite, LLC : https://bluebite.com\n// Submitted by Joshua Weiss <admin.engineering@bluebite.com>\nbluebite.io\n\n//
+        Boomla : https://boomla.com\n// Submitted by Tibor Halter <thalter@boomla.com>\nboomla.net\n\n//
+        Boutir : https://www.boutir.com\n// Submitted by Eric Ng Ka Ka <ngkaka@boutir.com>\nboutir.com\n\n//
+        Boxfuse : https://boxfuse.com\n// Submitted by Axel Fontaine <axel@boxfuse.com>\nboxfuse.io\n\n//
+        bplaced : https://www.bplaced.net/\n// Submitted by Miroslav Bozic <security@bplaced.net>\nsquare7.ch\nbplaced.com\nbplaced.de\nsquare7.de\nbplaced.net\nsquare7.net\n\n//
+        Brave : https://brave.com\n// Submitted by Andrea Brancaleoni <abrancaleoni@brave.com>\nbrave.app\n*.s.brave.app\nbrave.dev\n*.s.brave.dev\nbrave.io\n*.s.brave.io\n\n//
+        Brendly : https://brendly.rs\n// Submitted by Dusan Radovanovic <administracija@brendly.rs>\nshop.brendly.ba\nshop.brendly.hr\nshop.brendly.rs\n\n//
+        BrowserSafetyMark\n// Submitted by Dave Tharp <browsersafetymark.io@quicinc.com>\nbrowsersafetymark.io\n\n//
+        BRS Media : https://brsmedia.com/\n// Submitted by Gavin Brown <gavin.brown@centralnic.com>\nradio.am\nradio.fm\n\n//
+        Bubble : https://bubble.io/\n// Submitted by Merlin Zhao <devops@bubble.io>\ncdn.bubble.io\nbubbleapps.io\n\n//
+        bwCloud-OS : https://bwcloud-os.de/\n// Submitted by Klara Mall <dns@bwcloud-os.de>\n*.bwcloud-os-instance.de\n\n//
+        Bytemark Hosting : https://www.bytemark.co.uk\n// Submitted by Paul Cammish
+        <paul.cammish@bytemark.co.uk>\nuk0.bigv.io\ndh.bytemark.co.uk\nvm.bytemark.co.uk\n\n//
+        Caf.js Labs LLC : https://www.cafjs.com\n// Submitted by Antonio Lain <antlai@cafjs.com>\ncafjs.com\n\n//
+        Canva Pty Ltd : https://canva.com/\n// Submitted by Joel Aquilina <publicsuffixlist@canva.com>\ncanva-apps.cn\nmy.canvasite.cn\ncanva-apps.com\ncanva-hosted-embed.com\ncanvacode.com\nrice-labs.com\ncanva.run\nmy.canva.site\n\n//
+        Carrd : https://carrd.co\n// Submitted by AJ <aj@carrd.co>\ndrr.ac\nuwu.ai\ncarrd.co\ncrd.co\nju.mp\n\n//
+        CDDO : https://www.gov.uk/guidance/get-an-api-domain-on-govuk\n// Submitted
+        by Jamie Tanna <jamie.tanna@digital.cabinet-office.gov.uk>\napi.gov.uk\n\n//
+        CDN77.com : http://www.cdn77.com\n// Submitted by Jan Krpes <jan.krpes@cdn77.com>\ncdn77-storage.com\nrsc.contentproxy9.cz\nr.cdn77.net\ncdn77-ssl.net\nc.cdn77.org\nrsc.cdn77.org\nssl.origin.cdn77-secure.org\n\n//
+        CentralNic : https://teaminternet.com/\n// Submitted by registry <gavin.brown@centralnic.com>\nza.bz\nbr.com\ncn.com\nde.com\neu.com\njpn.com\nmex.com\nru.com\nsa.com\nuk.com\nus.com\nza.com\ncom.de\ngb.net\nhu.net\njp.net\nse.net\nuk.net\nae.org\ncom.se\n\n//
+        Cityhost LLC : https://cityhost.ua\n// Submitted by Maksym Rivtin <support@cityhost.net.ua>\ncx.ua\n\n//
+        Civilized Discourse Construction Kit, Inc. : https://www.discourse.org/\n//
+        Submitted by Rishabh Nambiar, Michael Brown, Rafael dos Santos Silva <team@discourse.org>\ndiscourse.diy\ndiscourse.group\ndiscourse.team\n\n//
+        Clerk : https://www.clerk.dev\n// Submitted by Colin Sidoti <systems@clerk.dev>\nclerk.app\nclerkstage.app\n*.lcl.dev\n*.lclstage.dev\n*.stg.dev\n*.stgstage.dev\n\n//
+        Clever Cloud : https://www.clever-cloud.com/\n// Submitted by Quentin Adam
+        <noc@clever-cloud.com>\ncleverapps.cc\n*.services.clever-cloud.com\ncleverapps.io\ncleverapps.tech\n\n//
+        ClickRising : https://clickrising.com/\n// Submitted by Umut Gumeli <infrastructure-publicsuffixlist@clickrising.com>\nclickrising.net\n\n//
+        Cloud DNS Ltd : http://www.cloudns.net\n// Submitted by Aleksander Hristov
+        <noc@cloudns.net> & Boyan Peychev <boyan@cloudns.net>\ncloudns.asia\ncloudns.be\ncloud-ip.biz\ncloudns.biz\ncloud-ip.cc\ncloudns.cc\ncloudns.ch\ncloudns.cl\ncloudns.club\nabrdns.com\ndnsabr.com\nip-ddns.com\ncloudns.cx\ncloudns.eu\ncloudns.in\ncloudns.info\nddns-ip.net\ndns-cloud.net\ndns-dynamic.net\ncloudns.nz\ncloudns.org\nip-dynamic.org\ncloudns.ph\ncloudns.pro\ncloudns.pw\ncloudns.us\n\n//
+        Cloud66 : https://www.cloud66.com/\n// Submitted by Khash Sajadi <khash@cloud66.com>\nc66.me\ncloud66.ws\n\n//
+        CloudAccess.net : https://www.cloudaccess.net/\n// Submitted by Pawel Panek
+        <noc@cloudaccess.net>\njdevcloud.com\nwpdevcloud.com\ncloudaccess.host\nfreesite.host\ncloudaccess.net\n\n//
+        Cloudbees, Inc. : https://www.cloudbees.com/\n// Submitted by Mohideen Shajith
+        <jaas-sre-infra@cloudbees.com>\ncloudbeesusercontent.io\n\n// Cloudera, Inc.
+        : https://www.cloudera.com/\n// Submitted by Kedarnath Waikar <security@cloudera.com>\n*.cloudera.site\n\n//
+        Cloudflare, Inc. : https://www.cloudflare.com/\n// Submitted by Cloudflare
+        Team <publicsuffixlist@cloudflare.com>\ncloudflare.app\ncf-ipfs.com\ncloudflare-ipfs.com\ntrycloudflare.com\npages.dev\nr2.dev\nworkers.dev\ncloudflare.net\ncdn.cloudflare.net\ncdn.cloudflareanycast.net\ncdn.cloudflarecn.net\ncdn.cloudflareglobal.net\n\n//
+        cloudscale.ch AG : https://www.cloudscale.ch/\n// Submitted by Gaudenz Steinlin
+        <support@cloudscale.ch>\ncust.cloudscale.ch\nobjects.lpg.cloudscale.ch\nobjects.rma.cloudscale.ch\nlpg.objectstorage.ch\nrma.objectstorage.ch\n\n//
+        Clovyr : https://clovyr.io\n// Submitted by Patrick Nielsen <patrick@clovyr.io>\nwnext.app\n\n//
+        CNPY : https://cnpy.gdn\n// Submitted by Angelo Gladding <angelo@lahacker.net>\ncnpy.gdn\n\n//
+        Co & Co : https://co-co.nl/\n// Submitted by Govert Versluis <govert@co-co.nl>\n*.otap.co\n\n//
+        co.ca : http://registry.co.ca/\nco.ca\n\n// co.com Registry, LLC : https://registry.co.com\n//
+        Submitted by Gavin Brown <gavin.brown@centralnic.com>\nco.com\n\n// Codeberg
+        e. V. : https://codeberg.org\n// Submitted by Moritz Marquardt <git@momar.de>\ncodeberg.page\n\n//
+        CodeSandbox B.V. : https://codesandbox.io\n// Submitted by Ives van Hoorne
+        <abuse@codesandbox.io>\ncsb.app\npreview.csb.app\n\n// CoDNS B.V.\nco.nl\nco.no\n\n//
+        Cognition AI, Inc. : https://cognition.ai\n// Submitted by Philip Papurt <domains@cognition.ai>\n*.devinapps.com\n\n//
+        Combell.com : https://www.combell.com\n// Submitted by Combell Team <support@combell.com>\nwebhosting.be\nprvw.eu\nhosting-cluster.nl\n\n//
+        Contentful GmbH : https://www.contentful.com\n// Submitted by Contentful Developer
+        Experience Team <prd-ecosystem-dx@contentful.com>\nctfcloud.net\n\n// Convex
+        : https://convex.dev/\n// Submitted by James Cowling <security@convex.dev>\nconvex.app\nconvex.cloud\neu-west-1.convex.cloud\nus-east-1.convex.cloud\nconvex.site\neu-west-1.convex.site\nus-east-1.convex.site\n\n//
+        Coordination Center for TLD RU and XN--P1AI : https://cctld.ru/en/domains/domens_ru/reserved/\n//
+        Submitted by George Georgievsky <gug@cctld.ru>\nac.ru\nedu.ru\ngov.ru\nint.ru\nmil.ru\n\n//
+        CoreSpeed, Inc. : https://corespeed.io\n// Submitted by CoreSpeed Team <ops@corespeed.io>\ncorespeed.app\n\n//
+        COSIMO GmbH : http://www.cosimo.de\n// Submitted by Rene Marticke <rmarticke@cosimo.de>\ndyn.cosidns.de\ndnsupdater.de\ndynamisches-dns.de\ninternet-dns.de\nl-o-g-i-n.de\ndynamic-dns.info\nfeste-ip.net\nknx-server.net\nstatic-access.net\n\n//
+        Craft Docs Ltd : https://www.craft.do/\n// Submitted by Zsombor Fuszenecker
+        <security@craft.do>\ncraft.me\n\n// Craynic, s.r.o. : http://www.craynic.com/\n//
+        Submitted by Ales Krajnik <ales.krajnik@craynic.com>\nrealm.cz\n\n// Crisp
+        IM SAS : https://crisp.chat/\n// Submitted by Baptiste Jamin <hostmaster@crisp.chat>\non.crisp.email\n\n//
+        Cryptonomic : https://cryptonomic.net/\n// Submitted by Andrew Cady <public-suffix-list@cryptonomic.net>\n*.cryptonomic.net\n\n//
+        cyber_Folks S.A. : https://cyberfolks.pl\n// Submitted by Bartlomiej Kida
+        <security@cyberfolks.pl>\ncfolks.pl\n\n// cyon GmbH : https://www.cyon.ch/\n//
+        Submitted by Dominic Luechinger <dol@cyon.ch>\ncyon.link\ncyon.site\n\n//
+        Dansk.net : http://www.dansk.net/\n// Submitted by Anani Voule <digital@digital.co.dk>\nbiz.dk\nco.dk\nfirm.dk\nreg.dk\nstore.dk\n\n//
+        dappnode.io : https://dappnode.io/\n// Submitted by Abel Boldu / DAppNode
+        Team <community@dappnode.io>\ndyndns.dappnode.io\n\n// Dark, Inc. : https://darklang.com\n//
+        Submitted by Paul Biggar <ops@darklang.com>\nbuiltwithdark.com\ndarklang.io\n\n//
+        DataDetect, LLC. : https://datadetect.com\n// Submitted by Andrew Banchich
+        <abanchich@sceven.com>\ndemo.datadetect.com\ninstance.datadetect.com\n\n//
+        Datawire, Inc : https://www.datawire.io\n// Submitted by Richard Li <secalert@datawire.io>\nedgestack.me\n\n//
+        Datto, Inc. : https://www.datto.com/\n// Submitted by Philipp Heckel <ph@datto.com>\ndattolocal.com\ndattorelay.com\ndattoweb.com\nmydatto.com\ndattolocal.net\nmydatto.net\n\n//
+        ddnss.de : https://www.ddnss.de/\n// Submitted by Robert Niedziela <webmaster@ddnss.de>\nddnss.de\ndyn.ddnss.de\ndyndns.ddnss.de\ndyn-ip24.de\ndyndns1.de\nhome-webserver.de\ndyn.home-webserver.de\nmyhome-server.de\nddnss.org\n\n//
+        Debian : https://www.debian.org/\n// Submitted by Peter Palfrader / Debian
+        Sysadmin Team <dsa-publicsuffixlist@debian.org>\ndebian.net\n\n// Definima
+        : http://www.definima.com/\n// Submitted by Maxence Bitterli <maxence@definima.com>\ndefinima.io\ndefinima.net\n\n//
+        Deno Land Inc : https://deno.com/\n// Submitted by Luca Casonato <hostmaster@deno.com>\ndeno.dev\ndeno-staging.dev\ndeno.net\nsandbox.deno.net\n\n//
+        DeployAgent : https://deployagent.com\n// Submitted by Danny <security@deployagent.com>\ndeployagent.com\n\n//
+        deSEC : https://desec.io/\n// Submitted by Peter Thomassen <peter@desec.io>\ndedyn.io\n\n//
+        Deta : https://www.deta.sh/\n// Submitted by Aavash Shrestha <aavash@deta.sh>\ndeta.app\ndeta.dev\n\n//
+        Deuxfleurs : https://deuxfleurs.fr\n// Submitted by Aeddis Desauw <ca@deuxfleurs.fr>\ndeuxfleurs.eu\ndeuxfleurs.page\n\n//
+        Developed Methods LLC : https://methods.dev\n// Submitted by Patrick Lorio
+        <security@playit.gg>\n*.at.ply.gg\nd6.ply.gg\njoinmc.link\nplayit.plus\n*.at.playit.plus\nwith.playit.plus\n\n//
+        Dfinity Foundation: https://dfinity.org/\n// Submitted by Dfinity Team <domains@dfinity.org>\nicp0.io\n*.raw.icp0.io\nicp1.io\n*.raw.icp1.io\n*.icp.net\ncaffeine.site\ncaffeine.xyz\n\n//
+        dhosting.pl Sp. z o.o. : https://dhosting.pl/\n// Submitted by Szczepan Redzioch
+        <bok@dhosting.pl>\nmybox.company\nintouch.email\nmybox.me\nmybox.page\ndfirma.pl\ndkonto.pl\nyou2.pl\n\n//
+        DigitalOcean App Platform : https://www.digitalocean.com/products/app-platform/\n//
+        Submitted by Braxton Huggins <psl-maintainers@digitalocean.com>\nondigitalocean.app\n\n//
+        DigitalOcean Spaces : https://www.digitalocean.com/products/spaces/\n// Submitted
+        by Robin H. Johnson <psl-maintainers@digitalocean.com>\n*.digitaloceanspaces.com\n\n//
+        DigitalPlat : https://www.digitalplat.org/\n// Submitted by Edward Hsing <contact@digitalplat.org>\nqzz.io\nus.kg\nxx.kg\ndpdns.org\n\n//
+        Discord Inc : https://discord.com\n// Submitted by Sahn Lam <slam@discordapp.com>\ndiscordsays.com\ndiscordsez.com\n\n//
+        DNS Africa Ltd : https://dns.business\n// Submitted by Calvin Browne <calvin@dns.business>\njozi.biz\n\n//
+        DNSHE : https://www.dnshe.com\n// Submitted by DNSHE Team <support@dnshe.com>\nccwu.cc\ncc.cd\nus.ci\nde5.net\n\n//
+        DNShome : https://www.dnshome.de/\n// Submitted by Norbert Auler <mail@dnshome.de>\ndnshome.de\n\n//
+        DotArai : https://www.dotarai.com/\n// Submitted by Atsadawat Netcharadsang
+        <atsadawat@dotarai.co.th>\nonline.th\nshop.th\n\n// dotScot Domains : https://domains.scot/\n//
+        Submitted by DNS Team <dns@domains.scot>\nco.scot\nme.scot\norg.scot\n\n//
+        DrayTek Corp. : https://www.draytek.com/\n// Submitted by Paul Fang <mis@draytek.com>\ndrayddns.com\n\n//
+        DreamCommerce : https://shoper.pl/\n// Submitted by Konrad Kotarba <konrad.kotarba@dreamcommerce.com>\nshoparena.pl\n\n//
+        DreamHost : http://www.dreamhost.com/\n// Submitted by Andrew Farmer <andrew.farmer@dreamhost.com>\ndreamhosters.com\n\n//
+        Dreamyoungs, Inc. : https://durumis.com\n// Submitted by Infra Team <infra@durumis.com>\ndurumis.com\n\n//
+        DuckDNS : http://www.duckdns.org/\n// Submitted by Richard Harper <richard@duckdns.org>\nduckdns.org\n\n//
+        dy.fi : http://dy.fi/\n// Submitted by Heikki Hannikainen <hessu@hes.iki.fi>\ndy.fi\ntunk.org\n\n//
+        DynDNS.com : http://www.dyndns.com/services/dns/dyndns/\ndyndns.biz\nfor-better.biz\nfor-more.biz\nfor-some.biz\nfor-the.biz\nselfip.biz\nwebhop.biz\nftpaccess.cc\ngame-server.cc\nmyphotos.cc\nscrapping.cc\nblogdns.com\ncechire.com\ndnsalias.com\ndnsdojo.com\ndoesntexist.com\ndontexist.com\ndoomdns.com\ndyn-o-saur.com\ndynalias.com\ndyndns-at-home.com\ndyndns-at-work.com\ndyndns-blog.com\ndyndns-free.com\ndyndns-home.com\ndyndns-ip.com\ndyndns-mail.com\ndyndns-office.com\ndyndns-pics.com\ndyndns-remote.com\ndyndns-server.com\ndyndns-web.com\ndyndns-wiki.com\ndyndns-work.com\nest-a-la-maison.com\nest-a-la-masion.com\nest-le-patron.com\nest-mon-blogueur.com\nfrom-ak.com\nfrom-al.com\nfrom-ar.com\nfrom-ca.com\nfrom-ct.com\nfrom-dc.com\nfrom-de.com\nfrom-fl.com\nfrom-ga.com\nfrom-hi.com\nfrom-ia.com\nfrom-id.com\nfrom-il.com\nfrom-in.com\nfrom-ks.com\nfrom-ky.com\nfrom-ma.com\nfrom-md.com\nfrom-mi.com\nfrom-mn.com\nfrom-mo.com\nfrom-ms.com\nfrom-mt.com\nfrom-nc.com\nfrom-nd.com\nfrom-ne.com\nfrom-nh.com\nfrom-nj.com\nfrom-nm.com\nfrom-nv.com\nfrom-oh.com\nfrom-ok.com\nfrom-or.com\nfrom-pa.com\nfrom-pr.com\nfrom-ri.com\nfrom-sc.com\nfrom-sd.com\nfrom-tn.com\nfrom-tx.com\nfrom-ut.com\nfrom-va.com\nfrom-vt.com\nfrom-wa.com\nfrom-wi.com\nfrom-wv.com\nfrom-wy.com\ngetmyip.com\ngotdns.com\nhobby-site.com\nhomelinux.com\nhomeunix.com\niamallama.com\nis-a-anarchist.com\nis-a-blogger.com\nis-a-bookkeeper.com\nis-a-bulls-fan.com\nis-a-caterer.com\nis-a-chef.com\nis-a-conservative.com\nis-a-cpa.com\nis-a-cubicle-slave.com\nis-a-democrat.com\nis-a-designer.com\nis-a-doctor.com\nis-a-financialadvisor.com\nis-a-geek.com\nis-a-green.com\nis-a-guru.com\nis-a-hard-worker.com\nis-a-hunter.com\nis-a-landscaper.com\nis-a-lawyer.com\nis-a-liberal.com\nis-a-libertarian.com\nis-a-llama.com\nis-a-musician.com\nis-a-nascarfan.com\nis-a-nurse.com\nis-a-painter.com\nis-a-personaltrainer.com\nis-a-photographer.com\nis-a-player.com\nis-a-republican.com\nis-a-rockstar.com\nis-a-socialist.com\nis-a-student.com\nis-a-teacher.com\nis-a-techie.com\nis-a-therapist.com\nis-an-accountant.com\nis-an-actor.com\nis-an-actress.com\nis-an-anarchist.com\nis-an-artist.com\nis-an-engineer.com\nis-an-entertainer.com\nis-certified.com\nis-gone.com\nis-into-anime.com\nis-into-cars.com\nis-into-cartoons.com\nis-into-games.com\nis-leet.com\nis-not-certified.com\nis-slick.com\nis-uberleet.com\nis-with-theband.com\nisa-geek.com\nisa-hockeynut.com\nissmarterthanyou.com\nlikes-pie.com\nlikescandy.com\nneat-url.com\nsaves-the-whales.com\nselfip.com\nsells-for-less.com\nsells-for-u.com\nservebbs.com\nsimple-url.com\nspace-to-rent.com\nteaches-yoga.com\nwritesthisblog.com\nath.cx\nfuettertdasnetz.de\nisteingeek.de\nistmein.de\nlebtimnetz.de\nleitungsen.de\ntraeumtgerade.de\nbarrel-of-knowledge.info\nbarrell-of-knowledge.info\ndyndns.info\nfor-our.info\ngroks-the.info\ngroks-this.info\nhere-for-more.info\nknowsitall.info\nselfip.info\nwebhop.info\nforgot.her.name\nforgot.his.name\nat-band-camp.net\nblogdns.net\nbroke-it.net\nbuyshouses.net\ndnsalias.net\ndnsdojo.net\ndoes-it.net\ndontexist.net\ndynalias.net\ndynathome.net\nendofinternet.net\nfrom-az.net\nfrom-co.net\nfrom-la.net\nfrom-ny.net\ngets-it.net\nham-radio-op.net\nhomeftp.net\nhomeip.net\nhomelinux.net\nhomeunix.net\nin-the-band.net\nis-a-chef.net\nis-a-geek.net\nisa-geek.net\nkicks-ass.net\noffice-on-the.net\npodzone.net\nscrapper-site.net\nselfip.net\nsells-it.net\nservebbs.net\nserveftp.net\nthruhere.net\nwebhop.net\nmerseine.nu\nmine.nu\nshacknet.nu\nblogdns.org\nblogsite.org\nboldlygoingnowhere.org\ndnsalias.org\ndnsdojo.org\ndoesntexist.org\ndontexist.org\ndoomdns.org\ndvrdns.org\ndynalias.org\ndyndns.org\ngo.dyndns.org\nhome.dyndns.org\nendofinternet.org\nendoftheinternet.org\nfrom-me.org\ngame-host.org\ngotdns.org\nhobby-site.org\nhomedns.org\nhomeftp.org\nhomelinux.org\nhomeunix.org\nis-a-bruinsfan.org\nis-a-candidate.org\nis-a-celticsfan.org\nis-a-chef.org\nis-a-geek.org\nis-a-knight.org\nis-a-linux-user.org\nis-a-patsfan.org\nis-a-soxfan.org\nis-found.org\nis-lost.org\nis-saved.org\nis-very-bad.org\nis-very-evil.org\nis-very-good.org\nis-very-nice.org\nis-very-sweet.org\nisa-geek.org\nkicks-ass.org\nmisconfused.org\npodzone.org\nreadmyblog.org\nselfip.org\nsellsyourhome.org\nservebbs.org\nserveftp.org\nservegame.org\nstuff-4-sale.org\nwebhop.org\nbetter-than.tv\ndyndns.tv\non-the-web.tv\nworse-than.tv\nis-by.us\nland-4-sale.us\nstuff-4-sale.us\ndyndns.ws\nmypets.ws\n\n//
+        Dynu.com : https://www.dynu.com/\n// Submitted by Sue Ye <psl-contact@dynu.com>\n1cooldns.com\nbumbleshrimp.com\nddnsfree.com\nddnsgeek.com\nddnsguru.com\ndynuddns.com\ndynuhosting.com\ngiize.com\ngleeze.com\nkozow.com\nloseyourip.com\nooguy.com\npivohosting.com\ntheworkpc.com\nwiredbladehosting.com\ncasacam.net\ndynu.net\ndynuddns.net\nmysynology.net\nopik.net\nspryt.net\naccesscam.org\ncamdvr.org\nfreeddns.org\nmywire.org\nroxa.org\nwebredirect.org\nmyddns.rocks\n\n//
+        dynv6 : https://dynv6.com\n// Submitted by Dominik Menke <dom@digineo.de>\ndynv6.net\n\n//
+        E4YOU spol. s.r.o. : https://e4you.cz/\n// Submitted by Vladimir Dudr <info@e4you.cz>\ne4.cz\n\n//
+        Easypanel : https://easypanel.io\n// Submitted by Andrei Canta <andrei@easypanel.io>\neasypanel.app\neasypanel.host\n\n//
+        EasyWP : https://www.easywp.com\n// Submitted by <infracloudteam@namecheap.com>\n*.ewp.live\n\n//
+        eDirect Corp. : https://hosting.url.com.tw/\n// Submitted by C.S. chang <cschang@corp.url.com.tw>\ntwmail.cc\ntwmail.net\ntwmail.org\nmymailer.com.tw\nurl.tw\n\n//
+        Electromagnetic Field : https://www.emfcamp.org\n// Submitted by <noc@emfcamp.org>\nat.emf.camp\n\n//
+        Elefunc, Inc. : https://elefunc.com\n// Submitted by Cetin Sert <domains@elefunc.com>\nrt.ht\n\n//
+        Elementor : Elementor Ltd.\n// Submitted by Anton Barkan <antonb@elementor.com>\nelementor.cloud\nelementor.cool\n\n//
+        Emergent : https://emergent.sh\n// Submitted by Emergent Security Team <security@emergent.sh>\nemergent.cloud\npreview.emergentagent.com\nemergent.host\n\n//
+        Enalean SAS : https://www.enalean.com\n// Submitted by Enalean Security Team
+        <security@enalean.com>\nmytuleap.com\ntuleap-partners.com\n\n// Encoretivity
+        AB : https://encore.cloud\n// Submitted by Andr\xE9 Eriksson <security@encore.cloud>\nencr.app\nfrontend.encr.app\nencoreapi.com\nlp.dev\napi.lp.dev\nobjects.lp.dev\n\n//
+        encoway GmbH : https://www.encoway.de\n// Submitted by Marcel Daus <cloudops@encoway.de>\neu.encoway.cloud\n\n//
+        EU.org : https://eu.org/\n// Submitted by Pierre Beyssac <hostmaster@eu.org>\neu.org\nal.eu.org\nasso.eu.org\nat.eu.org\nau.eu.org\nbe.eu.org\nbg.eu.org\nca.eu.org\ncd.eu.org\nch.eu.org\ncn.eu.org\ncy.eu.org\ncz.eu.org\nde.eu.org\ndk.eu.org\nedu.eu.org\nee.eu.org\nes.eu.org\nfi.eu.org\nfr.eu.org\ngr.eu.org\nhr.eu.org\nhu.eu.org\nie.eu.org\nil.eu.org\nin.eu.org\nint.eu.org\nis.eu.org\nit.eu.org\njp.eu.org\nkr.eu.org\nlt.eu.org\nlu.eu.org\nlv.eu.org\nme.eu.org\nmk.eu.org\nmt.eu.org\nmy.eu.org\nnet.eu.org\nng.eu.org\nnl.eu.org\nno.eu.org\nnz.eu.org\npl.eu.org\npt.eu.org\nro.eu.org\nru.eu.org\nse.eu.org\nsi.eu.org\nsk.eu.org\ntr.eu.org\nuk.eu.org\nus.eu.org\n\n//
+        Eurobyte : https://eurobyte.ru\n// Submitted by Evgeniy Subbotin <e.subbotin@eurobyte.ru>\neurodir.ru\n\n//
+        Evennode : http://www.evennode.com/\n// Submitted by Michal Kralik <support@evennode.com>\neu-1.evennode.com\neu-2.evennode.com\neu-3.evennode.com\neu-4.evennode.com\nus-1.evennode.com\nus-2.evennode.com\nus-3.evennode.com\nus-4.evennode.com\n\n//
+        Evervault : https://evervault.com\n// Submitted by Hannah Neary <engineering@evervault.com>\nrelay.evervault.app\nrelay.evervault.dev\n\n//
+        Exe : https://exe.dev\n// Submitted by Josh Bleecher Snyder <security@exe.dev>\nexe.xyz\n\n//
+        Expo : https://expo.dev/\n// Submitted by Phil Pluckthun <psl@expo.dev>\nexpo.app\non.expo.app\nstaging.expo.app\non.staging.expo.app\n\n//
+        Fabrica Technologies, Inc. : https://www.fabrica.dev/\n// Submitted by Eric
+        Jiang <eric@fabrica.dev>\nonfabrica.com\n\n// FAITID : https://faitid.org/\n//
+        Submitted by Maxim Alzoba <tech.contact@faitid.org>\n// https://www.flexireg.net/stat_info\nru.net\nadygeya.ru\nbashkiria.ru\nbir.ru\ncbg.ru\ncom.ru\ndagestan.ru\ngrozny.ru\nkalmykia.ru\nkustanai.ru\nmarine.ru\nmordovia.ru\nmsk.ru\nmytis.ru\nnalchik.ru\nnov.ru\npyatigorsk.ru\nspb.ru\nvladikavkaz.ru\nvladimir.ru\nabkhazia.su\nadygeya.su\naktyubinsk.su\narkhangelsk.su\narmenia.su\nashgabad.su\nazerbaijan.su\nbalashov.su\nbashkiria.su\nbryansk.su\nbukhara.su\nchimkent.su\ndagestan.su\neast-kazakhstan.su\nexnet.su\ngeorgia.su\ngrozny.su\nivanovo.su\njambyl.su\nkalmykia.su\nkaluga.su\nkaracol.su\nkaraganda.su\nkarelia.su\nkhakassia.su\nkrasnodar.su\nkurgan.su\nkustanai.su\nlenug.su\nmangyshlak.su\nmordovia.su\nmsk.su\nmurmansk.su\nnalchik.su\nnavoi.su\nnorth-kazakhstan.su\nnov.su\nobninsk.su\npenza.su\npokrovsk.su\nsochi.su\nspb.su\ntashkent.su\ntermez.su\ntogliatti.su\ntroitsk.su\ntselinograd.su\ntula.su\ntuva.su\nvladikavkaz.su\nvladimir.su\nvologda.su\n\n//
+        Fancy Bits, LLC : http://getchannels.com\n// Submitted by Aman Gupta <aman@getchannels.com>\nchannelsdvr.net\nu.channelsdvr.net\n\n//
+        Fastly Inc. : http://www.fastly.com/\n// Submitted by Fastly Security <security@fastly.com>\nedgecompute.app\nfastly-edge.com\nfastly-terrarium.com\nfreetls.fastly.net\nmap.fastly.net\na.prod.fastly.net\nglobal.prod.fastly.net\na.ssl.fastly.net\nb.ssl.fastly.net\nglobal.ssl.fastly.net\nfastlylb.net\nmap.fastlylb.net\n\n//
+        Fastmail : https://www.fastmail.com/\n// Submitted by Marc Bradshaw <marc@fastmailteam.com>\n*.user.fm\n\n//
+        FASTVPS EESTI OU : https://fastvps.ru/\n// Submitted by Likhachev Vasiliy
+        <lihachev@fastvps.ru>\nfastvps-server.com\nfastvps.host\nmyfast.host\nfastvps.site\nmyfast.space\n\n//
+        FearWorks Media Ltd. : https://fearworksmedia.co.uk\n// Submitted by Keith
+        Fairley <domains@fearworksmedia.co.uk>\nconn.uk\ncopro.uk\nhosp.uk\n\n// Fedora
+        : https://fedoraproject.org/\n// Submitted by Patrick Uiterwijk <puiterwijk@fedoraproject.org>\nfedorainfracloud.org\nfedorapeople.org\ncloud.fedoraproject.org\napp.os.fedoraproject.org\napp.os.stg.fedoraproject.org\n\n//
+        Fermax : https://fermax.com/\n// Submitted by Koen Van Isterdael <k.vanisterdael@fermax.be>\nmydobiss.com\n\n//
+        FH Muenster : https://www.fh-muenster.de\n// Submitted by Robin Naundorf <r.naundorf@fh-muenster.de>\nfh-muenster.io\n\n//
+        Figma : https://www.figma.com\n// Submitted by Nick Frost <psl@figma.com>\npayload.dev\nfigma.site\nfigma-gov.site\npreview.site\n\n//
+        Filegear Inc. : https://www.filegear.com\n// Submitted by Jason Zhu <jason@owtware.com>\nfilegear.me\n\n//
+        Firebase, Inc.\n// Submitted by Chris Raynor <chris@firebase.com>\nfirebaseapp.com\n\n//
+        FlashDrive : https://flashdrive.io\n// Submitted by Eric Chan <support@flashdrive.io>\nfldrv.com\n\n//
+        Fleek Labs Inc : https://fleek.xyz\n// Submitted by Parsa Ghadimi <dev@fleek.xyz>\non-fleek.app\n\n//
+        FlutterFlow : https://flutterflow.io\n// Submitted by Anton Emelyanov <anton@flutterflow.io>\nflutterflow.app\n\n//
+        fly.io : https://fly.io\n// Submitted by Kurt Mackey <ops@fly.io>\nsprites.app\nfly.dev\n\n//
+        FoundryLabs, Inc : https://e2b.dev/\n// Submitted by Jiri Sveceny <security@e2b.dev>\ne2b.app\n\n//
+        Framer : https://www.framer.com\n// Submitted by Koen Rouwhorst <security@framer.com>\nframer.ai\nframer.app\nframercanvas.com\nframer.media\nframer.photos\nframer.website\nframer.wiki\n\n//
+        Frederik Braun : https://frederik-braun.com\n// Submitted by Frederik Braun
+        <fb@frederik-braun.com>\n*.0e.vc\n\n// Freebox : http://www.freebox.fr\n//
+        Submitted by Romain Fliedel <rfliedel@freebox.fr>\nfreebox-os.com\nfreeboxos.com\nfbx-os.fr\nfbxos.fr\nfreebox-os.fr\nfreeboxos.fr\n\n//
+        freedesktop.org : https://www.freedesktop.org\n// Submitted by Daniel Stone
+        <daniel@fooishbar.org>\nfreedesktop.org\n\n// freemyip.com : https://freemyip.com\n//
+        Submitted by Cadence <contact@freemyip.com>\nfreemyip.com\n\n// Frusky MEDIA&PR
+        : https://www.frusky.de\n// Submitted by Victor Pupynin <hallo@frusky.de>\n*.frusky.de\n\n//
+        FunkFeuer - Verein zur F\xF6rderung freier Netze : https://www.funkfeuer.at\n//
+        Submitted by Daniel A. Maierhofer <vorstand@funkfeuer.at>\nwien.funkfeuer.at\n\n//
+        Future Versatile Group. : https://www.fvg-on.net/\n// T.Kabu <webmaster@fvg-on.net>\ndaemon.asia\ndix.asia\nmydns.bz\n0am.jp\n0g0.jp\n0j0.jp\n0t0.jp\nmydns.jp\npgw.jp\nwjg.jp\nkeyword-on.net\nlive-on.net\nserver-on.net\nmydns.tw\nmydns.vc\n\n//
+        Futureweb GmbH : https://www.futureweb.at\n// Submitted by Andreas Schnederle-Wagner
+        <schnederle@futureweb.at>\n*.futurecms.at\n*.ex.futurecms.at\n*.in.futurecms.at\nfuturehosting.at\nfuturemailing.at\n*.ex.ortsinfo.at\n*.kunden.ortsinfo.at\n*.statics.cloud\n\n//
+        Gadget Software Inc. : https://gadget.dev\n// Submitted by Harry Brundage
+        <security@gadget.dev>\ngadget.app\ngadget.host\n\n// GCom Internet : https://www.gcom.net.au\n//
+        Submitted by Leo Julius <support@gcom.net.au>\naliases121.com\n\n// GDS :
+        https://www.gov.uk/service-manual/technology/managing-domain-names\n// Submitted
+        by Stephen Ford <hostmaster@digital.cabinet-office.gov.uk>\ncampaign.gov.uk\nservice.gov.uk\nindependent-commission.uk\nindependent-inquest.uk\nindependent-inquiry.uk\nindependent-panel.uk\nindependent-review.uk\npublic-inquiry.uk\nroyal-commission.uk\n\n//
+        Gehirn Inc. : https://www.gehirn.co.jp/\n// Submitted by Kohei YOSHIDA <tech@gehirn.co.jp>\ngehirn.ne.jp\nusercontent.jp\n\n//
+        Gentlent, Inc. : https://www.gentlent.com\n// Submitted by Tom Klein <tom@gentlent.com>\ngentapps.com\ngentlentapis.com\ncdn-edges.net\n\n//
+        GignoSystemJapan : http://gsj.bz\n// Submitted by GignoSystemJapan <kakutou-ec@gsj.bz>\ngsj.bz\n\n//
+        GitBook Inc. : https://www.gitbook.com/\n// Submitted by Samy Pesse <devs@gitbook.com>\ngitbook.io\n\n//
+        GitHub, Inc.\n// Submitted by Patrick Toomey <security@github.com>\ngithub.app\ngithubusercontent.com\ngithubpreview.dev\ngithub.io\n\n//
+        GitLab, Inc. : https://about.gitlab.com/\n// Submitted by Alex Hanselka <alex@gitlab.com>\ngitlab.io\n\n//
+        Gitplac.si : https://gitplac.si\n// Submitted by Alja\u017E Starc <me@aljaxus.eu>\ngitapp.si\ngitpage.si\n\n//
+        Global NOG Alliance : https://nogalliance.org/\n// Submitted by Sander Steffann
+        <sander@nogalliance.org>\nnog.community\n\n// Globe Hosting SRL : https://www.globehosting.com/\n//
+        Submitted by Gavin Brown <gavin.brown@centralnic.com>\nco.ro\nshop.ro\n\n//
+        GMO Pepabo, Inc. : https://pepabo.com/\n// Submitted by Hosting Div <admin@pepabo.com>\nlolipop.io\nangry.jp\nbabyblue.jp\nbabymilk.jp\nbackdrop.jp\nbambina.jp\nbitter.jp\nblush.jp\nboo.jp\nboy.jp\nboyfriend.jp\nbut.jp\ncandypop.jp\ncapoo.jp\ncatfood.jp\ncheap.jp\nchicappa.jp\nchillout.jp\nchips.jp\nchowder.jp\nchu.jp\nciao.jp\ncocotte.jp\ncoolblog.jp\ncranky.jp\ncutegirl.jp\ndaa.jp\ndeca.jp\ndeci.jp\ndigick.jp\negoism.jp\nfakefur.jp\nfem.jp\nflier.jp\nfloppy.jp\nfool.jp\nfrenchkiss.jp\ngirlfriend.jp\ngirly.jp\ngloomy.jp\ngonna.jp\ngreater.jp\nhacca.jp\nheavy.jp\nher.jp\nhiho.jp\nhippy.jp\nholy.jp\nhungry.jp\nicurus.jp\nitigo.jp\njellybean.jp\nkikirara.jp\nkill.jp\nkilo.jp\nkuron.jp\nlittlestar.jp\nlolipopmc.jp\nlolitapunk.jp\nlomo.jp\nlovepop.jp\nlovesick.jp\nmain.jp\nmods.jp\nmond.jp\nmongolian.jp\nmoo.jp\nnamaste.jp\nnikita.jp\nnobushi.jp\nnoor.jp\noops.jp\nparallel.jp\nparasite.jp\npecori.jp\npeewee.jp\npenne.jp\npepper.jp\nperma.jp\npigboat.jp\npinoko.jp\npunyu.jp\npupu.jp\npussycat.jp\npya.jp\nraindrop.jp\nreadymade.jp\nsadist.jp\nschoolbus.jp\nsecret.jp\nstaba.jp\nstripper.jp\nsub.jp\nsunnyday.jp\nthick.jp\ntonkotsu.jp\nunder.jp\nupper.jp\nvelvet.jp\nverse.jp\nversus.jp\nvivian.jp\nwatson.jp\nweblike.jp\nwhitesnow.jp\nzombie.jp\nheteml.net\n\n//
+        GoDaddy Registry : https://registry.godaddy\n// Submitted by Rohan Durrant
+        <tldns@registry.godaddy>\ngraphic.design\n\n// GoIP DNS Services : http://www.goip.de\n//
+        Submitted by Christian Poulter <milchstrasse@goip.de>\ngoip.de\n\n// Google,
+        Inc.\n// Submitted by Shannon McCabe <public-suffix-editors@google.com>\n*.hosted.app\n*.run.app\n*.mtls.run.app\nweb.app\n*.0emm.com\nappspot.com\n*.r.appspot.com\nblogspot.com\ncodespot.com\ngoogleapis.com\ngooglecode.com\npagespeedmobilizer.com\nwithgoogle.com\nwithyoutube.com\n*.gateway.dev\ncloud.goog\ntranslate.goog\n*.usercontent.goog\ncloudfunctions.net\n\n//
+        Goupile : https://goupile.fr\n// Submitted by Niels Martignene <hello@goupile.fr>\ngoupile.fr\n\n//
+        GOV.UK Pay : https://www.payments.service.gov.uk/\n// Submitted by Richard
+        Baker <richard.baker@digital.cabinet-office.gov.uk>\npymnt.uk\n\n// GOV.UK
+        Platform as a Service : https://www.cloud.service.gov.uk/\n// Submitted by
+        Tom Whitwell <gov-uk-paas-support@digital.cabinet-office.gov.uk>\ncloudapps.digital\nlondon.cloudapps.digital\n\n//
+        Government of the Netherlands : https://www.government.nl\n// Submitted by
+        <domeinnaam@minaz.nl>\ngov.nl\n\n// Grafana Labs : https://grafana.com/\n//
+        Submitted by Platform Engineering <info@grafana.com>\ngrafana-dev.net\n\n//
+        GrayJay Web Solutions Inc. : https://grayjaysports.ca\n// Submitted by Matt
+        Yamkowy <info@grayjaysports.ca>\ngrayjayleagues.com\n\n// Grebedoc : https://grebedoc.dev\n//
+        Submitted by Catherine Zotova <admin@grebedoc.dev>\ngrebedoc.dev\n\n// G\xFCnstigBestellen
+        : https://g\xFCnstigbestellen.de\n// Submitted by Furkan Akkoc <info@hendelzon.de>\ng\xFCnstigbestellen.de\ng\xFCnstigliefern.de\n\n//
+        GV.UY : https://nic.gv.uy\n// Submitted by cheng <admin@mailto.al>\ngv.uy\n\n//
+        Hackclub Nest : https://hackclub.app\n// Submitted by Cyteon <admins@hackclub.app>\nhackclub.app\n\n//
+        H\xE4kkinen.fi : https://www.h\xE4kkinen.fi/\n// Submitted by Eero H\xE4kkinen
+        <Eero+psl@H\xE4kkinen.fi>\nh\xE4kkinen.fi\n\n// Hashbang : https://hashbang.sh\nhashbang.sh\n\n//
+        Hasura : https://hasura.io\n// Submitted by Shahidh K Muhammed <shahidh@hasura.io>\nhasura.app\nhasura-app.io\n\n//
+        Hatena Co., Ltd. : https://hatena.co.jp\n// Submitted by Masato Nakamura <blog-developers@hatena.ne.jp>\nhatenablog.com\nhatenadiary.com\nhateblo.jp\nhatenablog.jp\nhatenadiary.jp\nhatenadiary.org\n\n//
+        Heilbronn University of Applied Sciences - Faculty Informatics (GitLab Pages)
+        : https://www.hs-heilbronn.de\n// Submitted by Richard Zowalla <it-admin@hs-heilbronn.de>\npages.it.hs-heilbronn.de\npages-research.it.hs-heilbronn.de\n\n//
+        HeiyuSpace : https://lazycat.cloud\n// Submitted by Xia Bin <admin@lazycat.cloud>\nheiyu.space\n\n//
+        Helio Networks : https://heliohost.org\n// Submitted by Ben Frede <admin@heliohost.org>\nhelioho.st\nheliohost.us\n\n//
+        Hepforge : https://www.hepforge.org\n// Submitted by David Grellscheid <admin@hepforge.org>\nhepforge.org\n\n//
+        Hercules : https://hercules.app\n// Submitted by Brendan Falk <security@hercules.app>\nonhercules.app\nhercules-app.com\nhercules-dev.com\n\n//
+        Heroku : https://www.heroku.com/\n// Submitted by Shumon Huque <public-dns@salesforce.com>\nherokuapp.com\n\n//
+        Heyflow : https://www.heyflow.com\n// Submitted by Mirko Nitschke <tech@heyflow.com>\nheyflow.page\nheyflow.site\n\n//
+        Hibernating Rhinos\n// Submitted by Oren Eini <oren@ravendb.net>\nravendb.cloud\nravendb.community\ndevelopment.run\nravendb.run\n\n//
+        HiDNS : https://www.hidoha.net\n// Submitted by ifeng <admin@hidoha.net>\nhidns.co\nhidns.vip\n\n//
+        home.pl S.A. : https://home.pl\n// Submitted by Krzysztof Wolski <krzysztof.wolski@home.eu>\nhomesklep.pl\n\n//
+        Homebase : https://homebase.id/\n// Submitted by Jason Babo <info@homebase.id>\n*.kin.one\n*.id.pub\n*.kin.pub\n\n//
+        HOOC AG : https://www.hooc.ch\n// Submitted by Fabrizio Steiner <info@hooc.ch>\nseprox.hooc.me\n\n//
+        Hoplix : https://www.hoplix.com\n// Submitted by Danilo De Franco<info@hoplix.shop>\nhoplix.shop\n\n//
+        HOSTBIP REGISTRY : https://www.hostbip.com/\n// Submitted by Atanunu Igbunuroghene
+        <publicsuffixlist@hostbip.com>\norx.biz\nbiz.ng\nco.biz.ng\ndl.biz.ng\ngo.biz.ng\nlg.biz.ng\non.biz.ng\ncol.ng\nfirm.ng\ngen.ng\nltd.ng\nngo.ng\nplc.ng\n\n//
+        HostyHosting : https://hostyhosting.com\nhostyhosting.io\n\n// Hugging Face
+        : https://huggingface.co\n// Submitted by Eliott Coyac <website@huggingface.co>\nhf.space\nstatic.hf.space\n\n//
+        Hypernode B.V. : https://www.hypernode.com/\n// Submitted by Cipriano Groenendal
+        <security@nl.team.blue>\nhypernode.io\n\n// I-O DATA DEVICE, INC. : http://www.iodata.com/\n//
+        Submitted by Yuji Minagawa <domains-admin@iodata.jp>\niobb.net\n\n// i-registry
+        s.r.o. : http://www.i-registry.cz/\n// Submitted by Martin Semrad <semrad@i-registry.cz>\nco.cz\n\n//
+        Ici la Lune : http://www.icilalune.com/\n// Submitted by Simon Morvan <simon@icilalune.com>\n*.moonscale.io\nmoonscale.net\n\n//
+        iDOT Services Limited : http://www.domain.gr.com\n// Submitted by Gavin Brown
+        <gavin.brown@centralnic.com>\ngr.com\n\n// iki.fi\n// Submitted by Hannu Aronsson
+        <haa@iki.fi>\niki.fi\n\n// iliad italia : https://www.iliad.it\n// Submitted
+        by Marios Makassikis <mmakassikis@freebox.fr>\nibxos.it\niliadboxos.it\n\n//
+        Imagine : https://imagine.dev\n// Submitted by Steven Nguyen <security@imagine.dev>\nimagine.diy\nimagine-proxy.work\n\n//
+        Incsub, LLC : https://incsub.com/\n// Submitted by Aaron Edwards <sysadmins@incsub.com>\nsmushcdn.com\nwphostedmail.com\nwpmucdn.com\ntempurl.host\nwpmudev.host\n\n//
+        Individual Network Berlin e.V. : https://www.in-berlin.de/\n// Submitted by
+        Christian Seitz <chris@in-berlin.de>\ndyn-berlin.de\nin-berlin.de\nin-brb.de\nin-butter.de\nin-dsl.de\nin-vpn.de\nin-dsl.net\nin-vpn.net\nin-dsl.org\nin-vpn.org\n\n//
+        Inferno Communications : https://inferno.co.uk\n// Submitted by Connor McFarlane
+        <noc@inferno.co.uk>\noninferno.net\n\n// info.at : http://www.info.at/\nbiz.at\ninfo.at\n\n//
+        info.cx : http://info.cx\n// Submitted by June Slater <whois@igloo.to>\ninfo.cx\n\n//
+        Interlegis : http://www.interlegis.leg.br\n// Submitted by Gabriel Ferreira
+        <registrobr@interlegis.leg.br>\nac.leg.br\nal.leg.br\nam.leg.br\nap.leg.br\nba.leg.br\nce.leg.br\ndf.leg.br\nes.leg.br\ngo.leg.br\nma.leg.br\nmg.leg.br\nms.leg.br\nmt.leg.br\npa.leg.br\npb.leg.br\npe.leg.br\npi.leg.br\npr.leg.br\nrj.leg.br\nrn.leg.br\nro.leg.br\nrr.leg.br\nrs.leg.br\nsc.leg.br\nse.leg.br\nsp.leg.br\nto.leg.br\n\n//
+        intermetrics GmbH : https://pixolino.com/\n// Submitted by Wolfgang Schwarz
+        <admin@intermetrics.de>\npixolino.com\n\n// Internet-Pro, LLP : https://netangels.ru/\n//
+        Submitted by Vasiliy Sheredeko <piphon@gmail.com>\nna4u.ru\n\n// Inventor
+        Services : https://inventor.gg/\n// Submitted by Inventor Team <psl@inventor.gg>\nbotdash.app\nbotdash.dev\nbotdash.gg\nbotdash.net\nbotda.sh\nbotdash.xyz\n\n//
+        IONOS SE : https://www.ionos.com/\n// IONOS Group SE : https://www.ionos-group.com/\n//
+        Submitted by Henrik Willert <security@ionos.com>\napps-1and1.com\nlive-website.com\nwebspace-host.com\napps-1and1.net\nwebsitebuilder.online\napp-ionos.space\n\n//
+        iopsys software solutions AB : https://iopsys.eu/\n// Submitted by Roman Azarenko
+        <roman.azarenko@iopsys.eu>\niopsys.se\n\n// IPFS Project : https://ipfs.tech/\n//
+        Submitted by Interplanetary Shipyard <domains@ipshipyard.com>\n*.inbrowser.dev\n*.dweb.link\n*.inbrowser.link\n\n//
+        IPiFony Systems, Inc. : https://www.ipifony.com/\n// Submitted by Matthew
+        Hardeman <mhardeman@ipifony.com>\nipifony.net\n\n// ir.md : https://nic.ir.md\n//
+        Submitted by Ali Soizi <info@nic.ir.md>\nir.md\n\n// is-a-good.dev : https://is-a-good.dev\n//
+        Submitted by William Harrison <webmaster@is-a-good.dev>\nis-a-good.dev\n\n//
+        IServ GmbH : https://iserv.de\n// Submitted by Kim Brodowski <info@iserv.de>\niservschule.de\nmein-iserv.de\nschuldock.de\nschulplattform.de\nschulserver.de\ntest-iserv.de\niserv.dev\niserv.host\n\n//
+        Ispmanager : https://www.ispmanager.com/\n// Submitted by Ispmanager infrastructure
+        team <infrastructure@ispmanager.com>\nispmanager.name\n\n// Jelastic, Inc.
+        : https://jelastic.com/\n// Submitted by Ihor Kolodyuk <ik@jelastic.com>\nmel.cloudlets.com.au\ncloud.interhostsolutions.be\nalp1.ae.flow.ch\nappengine.flow.ch\nes-1.axarnet.cloud\ndiadem.cloud\nvip.jelastic.cloud\njele.cloud\nit1.eur.aruba.jenv-aruba.cloud\nit1.jenv-aruba.cloud\nkeliweb.cloud\ncs.keliweb.cloud\noxa.cloud\ntn.oxa.cloud\nuk.oxa.cloud\nprimetel.cloud\nuk.primetel.cloud\nca.reclaim.cloud\nuk.reclaim.cloud\nus.reclaim.cloud\nch.trendhosting.cloud\nde.trendhosting.cloud\njele.club\ndopaas.com\npaas.hosted-by-previder.com\nrag-cloud.hosteur.com\nrag-cloud-ch.hosteur.com\njcloud.ik-server.com\njcloud-ver-jpc.ik-server.com\ndemo.jelastic.com\npaas.massivegrid.com\njed.wafaicloud.com\nryd.wafaicloud.com\nj.scaleforce.com.cy\njelastic.dogado.eu\nfi.cloudplatform.fi\ndemo.datacenter.fi\npaas.datacenter.fi\njele.host\nmircloud.host\npaas.beebyte.io\nsekd1.beebyteapp.io\njele.io\njc.neen.it\njcloud.kz\ncloudjiffy.net\nfra1-de.cloudjiffy.net\nwest1-us.cloudjiffy.net\njls-sto1.elastx.net\njls-sto2.elastx.net\njls-sto3.elastx.net\nfr-1.paas.massivegrid.net\nlon-1.paas.massivegrid.net\nlon-2.paas.massivegrid.net\nny-1.paas.massivegrid.net\nny-2.paas.massivegrid.net\nsg-1.paas.massivegrid.net\njelastic.saveincloud.net\nnordeste-idc.saveincloud.net\nj.scaleforce.net\nsdscloud.pl\nunicloud.pl\nmircloud.ru\nenscaled.sg\njele.site\njelastic.team\norangecloud.tn\nj.layershift.co.uk\nphx.enscaled.us\nmircloud.us\n\n//
+        Jino : https://www.jino.ru\n// Submitted by Sergey Ulyashin <ulyashin@jino.ru>\nmyjino.ru\n*.hosting.myjino.ru\n*.landing.myjino.ru\n*.spectrum.myjino.ru\n*.vps.myjino.ru\n\n//
+        Jotelulu S.L. : https://jotelulu.com\n// Submitted by Daniel Fari\xF1a <ingenieria@jotelulu.com>\njote.cloud\njotelulu.cloud\neu1-plenit.com\nla1-plenit.com\nus1-plenit.com\n\n//
+        JouwWeb B.V. : https://www.jouwweb.nl\n// Submitted by Camilo Sperberg <tech@webador.com>\nwebadorsite.com\njouwweb.site\n\n//
+        JS.ORG : http://dns.js.org\n// Submitted by Stefan Keim <admin@js.org>\njs.org\n\n//
+        K2 Cloud : https://k2.cloud/\n// Submitted by K2 Cloud <compliance@k2.cloud>\nelastic.k2.cloud\nlb.ru-msk.k2.cloud\ns3.ru-msk.k2.cloud\nwebsite.ru-msk.k2.cloud\nlb.ru-spb.k2.cloud\ns3.ru-spb.k2.cloud\nwebsite.ru-spb.k2.cloud\ns3.k2.cloud\nwebsite.k2.cloud\n\n//
+        KaasHosting : http://www.kaashosting.nl/\n// Submitted by Wouter Bakker <hostmaster@kaashosting.nl>\nkaas.gg\nkhplay.nl\n\n//
+        Kapsi : https://kapsi.fi\n// Submitted by Tomi Juntunen <erani@kapsi.fi>\nkapsi.fi\n\n//
+        KataBump : https://katabump.com\n// Submitted by Thibault Lapeyre <contact@katabump.com>\nkdns.fr\n\n//
+        Katholieke Universiteit Leuven : https://www.kuleuven.be\n// Submitted by
+        Abuse KU Leuven <abuse@kuleuven.be>\nezproxy.kuleuven.be\nkuleuven.cloud\n\n//
+        Keenetic : https://keenetic.com\n// Submitted by Alexey Nikitin <cloud@keenetic.net>\nkeenetic.io\nkeenetic.link\nkeenetic.name\nkeenetic.pro\n\n//
+        Kevin Service : https://kevsrv.me\n// Submitted by Kevin Service Team <cs@kevsrv.me>\nae.kg\n\n//
+        Keyweb AG : https://www.keyweb.de\n// Submitted by Martin Dannehl <postmaster@keymachine.de>\nkeymachine.de\n\n//
+        Kilo Code, Inc. : https://kilo.ai\n// Submitted by Remon Oldenbeuving <security@kilocode.ai>\nkiloapps.ai\nkiloapps.io\n\n//
+        KingHost : https://king.host\n// Submitted by Felipe Keller Braz <felipebraz@kinghost.com.br>\nkinghost.net\nuni5.net\n\n//
+        KnightPoint Systems, LLC : http://www.knightpoint.com/\n// Submitted by Roy
+        Keene <rkeene@knightpoint.com>\nknightpoint.systems\n\n// KoobinEvent, SL
+        : https://www.koobin.com\n// Submitted by Iv\xE1n Oliva <ivan.oliva@koobin.com>\nkoobin.events\n\n//
+        Krellian Ltd. : https://krellian.com\n// Submitted by Ben Francis <ben@krellian.com>\nwebthings.io\nkrellian.net\n\n//
+        KUROKU LTD : https://kuroku.ltd/\n// Submitted by DisposaBoy <security@oya.to>\noya.to\n\n//
+        KV GmbH : https://www.nic.co.de\n// Submitted by KV GmbH <registry@kv-gmbh.de>\n//
+        Abuse reports to <registry@kv-gmbh.de>\nco.de\n\n// Laravel Holdings, Inc.
+        : https://laravel.com\n// Submitted by Andr\xE9 Valentin & James Brooks <security@laravel.com>\nshiptoday.app\nshiptoday.build\nlaravel.cloud\non-forge.com\non-vapor.com\n\n//
+        LCube - Professional hosting e.K. : https://www.lcube-webhosting.de\n// Submitted
+        by Lars Laehn <info@lcube.de>\ngit-repos.de\nlcube-server.de\nsvn-repos.de\n\n//
+        Leadpages : https://www.leadpages.net\n// Submitted by Greg Dallavalle <domains@leadpages.net>\nleadpages.co\nlpages.co\nlpusercontent.com\n\n//
+        Leapcell : https://leapcell.io/\n// Submitted by Leapcell Team <support@leapcell.io>\nleapcell.app\nleapcell.dev\nleapcell.online\n\n//
+        Liara : https://liara.ir\n// Submitted by Amirhossein Badinloo <info@liara.ir>\nliara.run\niran.liara.run\n\n//
+        libp2p project : https://libp2p.io\n// Submitted by Interplanetary Shipyard
+        <domains@ipshipyard.com>\nlibp2p.direct\n\n// Libre IT Ltd : https://libre.nz\n//
+        Submitted by Tomas Maggio <support@libre.nz>\nruncontainers.dev\n\n// Lifetime
+        Hosting : https://Lifetime.Hosting/\n// Submitted by Mike Fillator <support@lifetime.hosting>\nco.business\nco.education\nco.events\nco.financial\nco.network\nco.place\nco.technology\n\n//
+        linkyard ldt : https://www.linkyard.ch/\n// Submitted by Mario Siegenthaler
+        <mario.siegenthaler@linkyard.ch>\nlinkyard-cloud.ch\nlinkyard.cloud\n\n//
+        Linode : https://linode.com\n// Submitted by <security@linode.com>\nmembers.linode.com\n*.nodebalancer.linode.com\n*.linodeobjects.com\nip.linodeusercontent.com\n\n//
+        LiquidNet Ltd : http://www.liquidnetlimited.com/\n// Submitted by Victor Velchev
+        <admin@liquidnetlimited.com>\nwe.bs\n\n// Listen53 : https://www.l53.net\n//
+        Submitted by Gerry Keh <biz@l53.net>\nfilegear-sg.me\nggff.net\n\n// Localcert
+        : https://localcert.dev\n// Submitted by Lann Martin <security@localcert.dev>\n*.user.localcert.dev\n\n//
+        Localtonet : https://localtonet.com/\n// Submitted by Burak Isleyici <support@localtonet.com>\nlocaltonet.com\n*.localto.net\n\n//
+        Lodz University of Technology LODMAN regional domains : https://www.man.lodz.pl/dns\n//
+        Submitted by Piotr Wilk <dns@man.lodz.pl>\nlodz.pl\npabianice.pl\nplock.pl\nsieradz.pl\nskierniewice.pl\nzgierz.pl\n\n//
+        Log'in Line : https://www.loginline.com/\n// Submitted by R\xE9mi Mach <remi.mach@loginline.com>\nloginline.app\nloginline.dev\nloginline.io\nloginline.services\nloginline.site\n\n//
+        L\xF5hmus Family, The : https://lohmus.me/\n// Submitted by Heiki L\xF5hmus
+        <hostmaster@lohmus.me>\nlohmus.me\n\n// Lovable : https://lovable.dev\n//
+        Submitted by Fabian Hedin <security@lovable.dev>\nlovable.app\nlovableproject.com\nlovable.run\nlovable.sh\n\n//
+        LubMAN UMCS Sp. z o.o : https://lubman.pl/\n// Submitted by Ireneusz Maliszewski
+        <ireneusz.maliszewski@lubman.pl>\nkrasnik.pl\nleczna.pl\nlubartow.pl\nlublin.pl\nponiatowa.pl\nswidnik.pl\n\n//
+        Lug.org.uk : https://lug.org.uk\n// Submitted by Jon Spriggs <admin@lug.org.uk>\nglug.org.uk\nlug.org.uk\nlugs.org.uk\n\n//
+        Lukanet Ltd : https://lukanet.com\n// Submitted by Anton Avramov <register@lukanet.com>\nbarsy.bg\nbarsy.club\nbarsycenter.com\nbarsyonline.com\nbarsy.de\nbarsy.dev\nbarsy.eu\nbarsy.gr\nbarsy.in\nbarsy.info\nbarsy.io\nbarsy.me\nbarsy.menu\nbarsyonline.menu\nbarsy.mobi\nbarsy.net\nbarsy.online\nbarsy.org\nbarsy.pro\nbarsy.pub\nbarsy.ro\nbarsy.rs\nbarsy.shop\nbarsyonline.shop\nbarsy.site\nbarsy.store\nbarsy.support\nbarsy.uk\nbarsy.co.uk\nbarsyonline.co.uk\n\n//
+        Lutra : https://lutra.ai\n// Submitted by Joshua Newman <public-suffix-list@lutra.ai>\n*.lutrausercontent.com\n\n//
+        Luyani Inc. : https://luyani.com/\n// Submitted by Umut Gumeli <public-suffix-list@luyani.com>\nluyani.app\nluyani.net\n\n//
+        Magento Commerce\n// Submitted by Damien Tournoud <dtournoud@magento.cloud>\n*.magentosite.cloud\n\n//
+        Magic Patterns : https://www.magicpatterns.com\n// Submitted by Teddy Ni <security@magicpatterns.com>\nmagicpatterns.app\nmagicpatternsapp.com\n\n//
+        Mail.Ru Group : https://hb.cldmail.ru\n// Submitted by Ilya Zaretskiy <zaretskiy@corp.mail.ru>\nhb.cldmail.ru\n\n//
+        MathWorks : https://www.mathworks.com/\n// Submitted by Emily Reed <psl-maintainers@groups.mathworks.com>\nmatlab.cloud\nmodelscape.com\nmwcloudnonprod.com\npolyspace.com\n\n//
+        May First - People Link : https://mayfirst.org/\n// Submitted by Jamie McClelland
+        <info@mayfirst.org>\nmayfirst.info\nmayfirst.org\n\n// McHost : https://mchost.ru\n//
+        Submitted by Evgeniy Subbotin <e.subbotin@mchost.ru>\nmcdir.me\nmcdir.ru\nvps.mcdir.ru\nmcpre.ru\n\n//
+        Mediatech : https://mediatech.by\n// Submitted by Evgeniy Kozhuhovskiy <ugenk@mediatech.by>\nmediatech.by\nmediatech.dev\n\n//
+        Medicom Health : https://medicomhealth.com\n// Submitted by Michael Olson
+        <molson@medicomhealth.com>\nhra.health\n\n// MedusaJS, Inc : https://medusajs.com/\n//
+        Submitted by Stevche Radevski <engineering@medusajs.com>\nmedusajs.app\n\n//
+        Memset hosting : https://www.memset.com\n// Submitted by Tom Whitwell <domains@memset.com>\nminiserver.com\nmemset.net\n\n//
+        Messerli Informatik AG : https://www.messerli.ch/\n// Submitted by Ruben Schmidmeister
+        <psl-maintainers@messerli.ch>\nmesserli.app\n\n// Meta Platforms, Inc. : https://meta.com/\n//
+        Submitted by Jacob Cordero <public-suffix@meta.com>\natmeta.com\napps.fbsbx.com\n\n//
+        MetaCentrum, CESNET z.s.p.o. : https://www.metacentrum.cz/en/\n// Submitted
+        by Zden\u011Bk \u0160ustr <zdenek.sustr@cesnet.cz> and Radim Jan\u010Da <janca@cesnet.cz>\n*.cloud.metacentrum.cz\ncustom.metacentrum.cz\nflt.cloud.muni.cz\nusr.cloud.muni.cz\n\n//
+        Meteor Development Group : https://www.meteor.com/hosting\n// Submitted by
+        Pierre Carrier <pierre@meteor.com>\nmeteorapp.com\neu.meteorapp.com\n\n//
+        Michau Enterprises Limited : http://www.co.pl/\nco.pl\n\n// Microsoft Corporation
+        : http://microsoft.com\n// Submitted by Public Suffix List Admin <msftpsladmin@microsoft.com>\n//
+        Managed by Corporate Domains\n// Microsoft Azure : https://home.azure\n*.azurecontainer.io\nazure-api.net\nazure-mobile.net\nazureedge.net\nazurefd.net\nazurestaticapps.net\n1.azurestaticapps.net\n2.azurestaticapps.net\n3.azurestaticapps.net\n4.azurestaticapps.net\n5.azurestaticapps.net\n6.azurestaticapps.net\n7.azurestaticapps.net\ncentralus.azurestaticapps.net\neastasia.azurestaticapps.net\neastus2.azurestaticapps.net\nwesteurope.azurestaticapps.net\nwestus2.azurestaticapps.net\nazurewebsites.net\ncloudapp.net\ntrafficmanager.net\nblob.core.usgovcloudapi.net\nfile.core.usgovcloudapi.net\nweb.core.usgovcloudapi.net\nservicebus.usgovcloudapi.net\nusgovcloudapp.net\nusgovtrafficmanager.net\nblob.core.windows.net\nfile.core.windows.net\nweb.core.windows.net\nservicebus.windows.net\nazure-api.us\nazurewebsites.us\n\n//
+        MikroTik : https://mikrotik.com\n// Submitted by MikroTik SysAdmin Team <support@mikrotik.com>\nroutingthecloud.com\nsn.mynetname.net\nroutingthecloud.net\nroutingthecloud.org\n\n//
+        Million Software, Inc : https://million.dev/\n// Submitted by Rayhan Noufal
+        Arayilakath <security@million.dev>\nsame-app.com\nsame-preview.com\n\n// minion.systems
+        : http://minion.systems\n// Submitted by Robert B\xF6ttinger <r@minion.systems>\ncsx.cc\n\n//
+        Miren, Inc. : https://miren.dev\n// Submitted by Miren Product Team <team-product@miren.dev>\nmiren.app\nmiren.systems\n\n//
+        Mittwald CM Service GmbH & Co. KG : https://mittwald.de\n// Submitted by Marco
+        Rieger <security@mittwald.de>\nmydbserver.com\nwebspaceconfig.de\nmittwald.info\nmittwaldserver.info\ntypo3server.info\nproject.space\n\n//
+        Mocha : https://getmocha.com\n// Submitted by Ben Reinhart <security@getmocha.com>\nmocha.app\nmochausercontent.com\nmocha-sandbox.dev\n\n//
+        MODX Systems LLC : https://modx.com\n// Submitted by Elizabeth Southwell <elizabeth@modx.com>\nmodx.dev\n\n//
+        Mozilla Foundation : https://mozilla.org/\n// Submitted by glob <glob@mozilla.com>\nbmoattachments.org\n\n//
+        MSK-IX : https://www.msk-ix.ru/\n// Submitted by Khannanov Roman <r.khannanov@msk-ix.ru>\nnet.ru\norg.ru\npp.ru\n\n//
+        MyOwn srl : https://www.myown.eu/\n// Submitted by Stephane Bouvard <support@myown.eu>\nmy.be\n\n//
+        Mythic Beasts : https://www.mythic-beasts.com\n// Submitted by Paul Cammish
+        <kelduum@mythic-beasts.com>\nhostedpi.com\ncaracal.mythic-beasts.com\ncustomer.mythic-beasts.com\nfentiger.mythic-beasts.com\nlynx.mythic-beasts.com\nocelot.mythic-beasts.com\noncilla.mythic-beasts.com\nonza.mythic-beasts.com\nsphinx.mythic-beasts.com\nvs.mythic-beasts.com\nx.mythic-beasts.com\nyali.mythic-beasts.com\ncust.retrosnub.co.uk\n\n//
+        Nabu Casa : https://www.nabucasa.com\n// Submitted by Paulus Schoutsen <infra@nabucasa.com>\nui.nabu.casa\n\n//
+        Needle Tools GmbH : https://needle.tools\n// Submitted by Felix Herbst <security@needle.tools>\nneedle.run\n\n//
+        Neo : https://www.neo.space\n// Submitted by Ankit Kulkarni <devops@co.site>\nco.site\n\n//
+        Net at Work Gmbh : https://www.netatwork.de\n// Submitted by Jan Jaeschke
+        <jan.jaeschke@netatwork.de>\ncloud.nospamproxy.com\no365.cloud.nospamproxy.com\n\n//
+        Net libre : https://www.netlib.re\n// Submitted by Philippe PITTOLI <security@netlib.re>\nnetlib.re\n\n//
+        Netlify : https://www.netlify.com\n// Submitted by Jessica Parsons <jessica@netlify.com>\nnetlify.app\n\n//
+        Neustar Inc.\n// Submitted by Trung Tran <Trung.Tran@neustar.biz>\n4u.com\n\n//
+        NFSN, Inc. : https://www.NearlyFreeSpeech.NET/\n// Submitted by Jeff Wheelhouse
+        <support@nearlyfreespeech.net>\nnfshost.com\n\n// NFT.Storage : https://nft.storage/\n//
+        Submitted by Vasco Santos <vasco.santos@protocol.ai> or <support@nft.storage>\nipfs.nftstorage.link\n\n//
+        NGO.US Registry : https://nic.ngo.us\n// Submitted by Alstra Solutions Ltd.
+        Networking Team <admin@alstra.org>\nngo.us\n\n// ngrok : https://ngrok.com/\n//
+        Submitted by Alan Shreve <alan@ngrok.com>\nngrok.app\nngrok-free.app\nngrok.dev\nngrok-free.dev\nngrok.io\nap.ngrok.io\nau.ngrok.io\neu.ngrok.io\nin.ngrok.io\njp.ngrok.io\nsa.ngrok.io\nus.ngrok.io\nngrok.pizza\nngrok.pro\n\n//
+        Nicolaus Copernicus University in Torun - MSK TORMAN : https://www.man.torun.pl\ntorun.pl\n\n//
+        Nimbus Hosting Ltd. : https://www.nimbushosting.co.uk/\n// Submitted by Nicholas
+        Ford <dev@nimbushosting.co.uk>\nnh-serv.co.uk\nnimsite.uk\n\n// No-IP.com
+        : https://noip.com/\n// Submitted by Deven Reza <publicsuffixlist@noip.com>\nmmafan.biz\nmyftp.biz\nno-ip.biz\nno-ip.ca\nfantasyleague.cc\ngotdns.ch\n3utilities.com\nblogsyte.com\nciscofreak.com\ndamnserver.com\nddnsking.com\nditchyourip.com\ndnsiskinky.com\ndynns.com\ngeekgalaxy.com\nhealth-carereform.com\nhomesecuritymac.com\nhomesecuritypc.com\nmyactivedirectory.com\nmysecuritycamera.com\nmyvnc.com\nnet-freaks.com\nonthewifi.com\npoint2this.com\nquicksytes.com\nsecuritytactics.com\nservebeer.com\nservecounterstrike.com\nserveexchange.com\nserveftp.com\nservegame.com\nservehalflife.com\nservehttp.com\nservehumour.com\nserveirc.com\nservemp3.com\nservep2p.com\nservepics.com\nservequake.com\nservesarcasm.com\nstufftoread.com\nunusualperson.com\nworkisboring.com\ndvrcam.info\nilovecollege.info\nno-ip.info\nbrasilia.me\nddns.me\ndnsfor.me\nhopto.me\nloginto.me\nnoip.me\nwebhop.me\nbounceme.net\nddns.net\neating-organic.net\nmydissent.net\nmyeffect.net\nmymediapc.net\nmypsx.net\nmysecuritycamera.net\nnhlfan.net\nno-ip.net\npgafan.net\nprivatizehealthinsurance.net\nredirectme.net\nserveblog.net\nserveminecraft.net\nsytes.net\ncable-modem.org\ncollegefan.org\ncouchpotatofries.org\nhopto.org\nmlbfan.org\nmyftp.org\nmysecuritycamera.org\nnflfan.org\nno-ip.org\nread-books.org\nufcfan.org\nzapto.org\nno-ip.co.uk\ngolffan.us\nnoip.us\npointto.us\n\n//
+        NodeArt : https://nodeart.io\n// Submitted by Konstantin Nosov <Nosov@nodeart.io>\nstage.nodeart.io\n\n//
+        Noop : https://noop.app\n// Submitted by Nathaniel Schweinberg <noop@rearc.io>\n*.developer.app\nnoop.app\n\n//
+        Northflank Ltd. : https://northflank.com/\n// Submitted by Marco Suter <marco@northflank.com>\n*.northflank.app\n*.build.run\n*.code.run\n*.database.run\n*.migration.run\n\n//
+        Northwest Nexus dba NuOz : https://nuoz.net/\n// An RFC 1480 locality domain
+        delegate host\n// Submitted by Peter Briggs on behalf of NuOz <domainsadmin@nuoz.com>\naberdeen.wa.us\nbainbridge-isl.wa.us\nbellevue.wa.us\nbremerton.wa.us\ncentralia.wa.us\nchehalis.wa.us\nforks.wa.us\ngig-harbor.wa.us\nhoquiam.wa.us\nkeyport.wa.us\nkingston.wa.us\nolympia.wa.us\nport-angeles.wa.us\nport-ludlow.wa.us\nport-orchard.wa.us\nport-townsend.wa.us\npoulsbo.wa.us\nredmond.wa.us\nrenton.wa.us\nsea.wa.us\nseattle.wa.us\nsequim.wa.us\nshelton.wa.us\nsilverdale.wa.us\nyarrow-point.wa.us\n\n//
+        Noticeable : https://noticeable.io\n// Submitted by Laurent Pellegrino <security@noticeable.io>\nnoticeable.news\n\n//
+        Notion Labs, Inc : https://www.notion.so/\n// Submitted by Jess Yao <trust-core-team@makenotion.com>\nnotion.site\n\n//
+        Now-DNS : https://now-dns.com\n// Submitted by Steve Russell <steve@now-dns.com>\ndnsking.ch\nmypi.co\nmyiphost.com\nforumz.info\nsoundcast.me\ntcp4.me\ndnsup.net\nhicam.net\nnow-dns.net\nownip.net\nvpndns.net\ndynserv.org\nnow-dns.org\nx443.pw\nntdll.top\nfreeddns.us\n\n//
+        nsupdate.info : https://www.nsupdate.info/\n// Submitted by Thomas Waldmann
+        <info@nsupdate.info>\nnsupdate.info\nnerdpol.ovh\n\n// O3O.Foundation : https://o3o.foundation/\n//
+        Submitted by the prvcy.page Registry Team <info@o3o.foundation>\nprvcy.page\n\n//
+        Observable, Inc. : https://observablehq.com\n// Submitted by Mike Bostock
+        <dns@observablehq.com>\nobservablehq.cloud\nstatic.observableusercontent.com\n\n//
+        OMG.LOL : https://omg.lol\n// Submitted by Adam Newbold <adam@omg.lol>\nomg.lol\n\n//
+        Omnibond Systems, LLC. : https://www.omnibond.com\n// Submitted by Cole Estep
+        <cole@omnibond.com>\ncloudycluster.net\n\n// OmniWe Limited : https://omniwe.com\n//
+        Submitted by Vicary Archangel <vicary@omniwe.com>\nomniwe.site\n\n// One.com
+        : https://www.one.com/\n// Submitted by Jacob Bunk Nielsen <jbn@one.com>\n123webseite.at\n123website.be\nsimplesite.com.br\n123website.ch\nsimplesite.com\n123webseite.de\n123hjemmeside.dk\n123miweb.es\n123kotisivu.fi\n123siteweb.fr\nsimplesite.gr\n123homepage.it\n123website.lu\n123website.nl\n123hjemmeside.no\nservice.one\nwebsite.one\nsimplesite.pl\n123paginaweb.pt\n123minsida.se\n\n//
+        ONID : https://get.onid.ca\n// Submitted by ONID Engineering Team <psl@onid.ca>\nonid.ca\n\n//
+        Open Domains : https://open-domains.net\n// Submitted by William Harrison
+        <admin@open-domains.net>\nis-a-fullstack.dev\nis-cool.dev\nis-not-a.dev\nlocalplayer.dev\nis-local.org\n\n//
+        Open Social : https://www.getopensocial.com/\n// Submitted by Alexander Varwijk
+        <security@getopensocial.com>\nopensocial.site\n\n// OpenAI : https://openai.com\n//
+        Submitted by Thomas Shadwell <security@openai.com>\n*.oaiusercontent.com\n\n//
+        OpenCraft GmbH : http://opencraft.com/\n// Submitted by Sven Marnach <sven@opencraft.com>\nopencraft.hosting\n\n//
+        OpenHost : https://registry.openhost.uk\n// Submitted by OpenHost Registry
+        Team <support@openhost.uk>\n16-b.it\n32-b.it\n64-b.it\n\n// OpenResearch GmbH
+        : https://openresearch.com/\n// Submitted by Philipp Schmid <ops@openresearch.com>\norsites.com\n\n//
+        Opera Software, A.S.A.\n// Submitted by Yngve Pettersen <yngve@opera.com>\noperaunite.com\n\n//
+        Oracle Dyn : https://cloud.oracle.com/home https://dyn.com/dns/\n// Submitted
+        by Gregory Drake <support@dyn.com>\n// Note: This is intended to also include
+        customer-oci.com due to wildcards implicitly including the current label\n*.customer-oci.com\n*.oci.customer-oci.com\n*.ocp.customer-oci.com\n*.ocs.customer-oci.com\n*.oraclecloudapps.com\n*.oraclegovcloudapps.com\n*.oraclegovcloudapps.uk\n\n//
+        Orange : https://www.orange.com\n// Submitted by Alexandre Linte <alexandre.linte@orange.com>\ntech.orange\n\n//
+        OsSav Technology Ltd. : https://ossav.com/\n// Submitted by OsSav Technology
+        Ltd. <support@ossav.com>\n// https://nic.can.re\ncan.re\n\n// Oursky Limited
+        : https://authgear.com/\n// Submitted by Authgear Team <hello@authgear.com>
+        & Skygear Developer <hello@skygear.io>\nauthgear-staging.com\nauthgearapps.com\n\n//
+        OutSystems\n// Submitted by Duarte Santos <domain-admin@outsystemscloud.com>\noutsystemscloud.com\n\n//
+        OVHcloud : https://ovhcloud.com\n// Submitted by Vincent Cass\xE9 <vincent.casse@ovhcloud.com>\n*.hosting.ovh.net\n*.webpaas.ovh.net\n\n//
+        OwnProvider GmbH : http://www.ownprovider.com\n// Submitted by Jan Moennich
+        <jan.moennich@ownprovider.com>\nownprovider.com\nown.pm\n\n// OwO : https://whats-th.is/\n//
+        Submitted by Dean Sheather <dean@deansheather.com>\n*.owo.codes\n\n// OX :
+        http://www.ox.rs\n// Submitted by Adam Grand <webmaster@mail.ox.rs>\nox.rs\n\n//
+        oy.lc\n// Submitted by Charly Coste <changaco@changaco.oy.lc>\noy.lc\n\n//
+        Pagefog : https://pagefog.com/\n// Submitted by Derek Myers <derek@pagefog.com>\npgfog.com\n\n//
+        Pantheon Systems, Inc. : https://pantheon.io/\n// Submitted by Gary Dylina
+        <gary@pantheon.io>\ngotpantheon.com\npantheonsite.io\n\n// Paywhirl, Inc :
+        https://paywhirl.com/\n// Submitted by Daniel Netzer <dan@paywhirl.com>\n*.paywhirl.com\n\n//
+        pcarrier.ca Software Inc : https://pcarrier.ca/\n// Submitted by Pierre Carrier
+        <pc@rrier.ca>\n*.xmit.co\nxmit.dev\nmadethis.site\nsrv.us\ngh.srv.us\ngl.srv.us\n\n//
+        Peplink | Pepwave : http://peplink.com/\n// Submitted by Steve Leung <steveleung@peplink.com>\nmypep.link\n\n//
+        Perplexity AI : https://www.perplexity.ai/\n// Submitted by Alec Xiang <security@perplexity.ai>\npplx.app\n\n//
+        Perspecta : https://perspecta.com/\n// Submitted by Kenneth Van Alstyne <kvanalstyne@perspecta.com>\nperspecta.cloud\n\n//
+        Ping Identity : https://www.pingidentity.com\n// Submitted by Ping Identity
+        <security@pingidentity.com>\nforgeblocks.com\nid.forgerock.io\n\n// Plain
+        : https://www.plain.com/\n// Submitted by Jes\xFAs Hern\xE1ndez <security@plain.com>\nsupport.site\n\n//
+        Planet-Work : https://www.planet-work.com/\n// Submitted by Fr\xE9d\xE9ric
+        VANNI\xC8RE <f.vanniere@planet-work.com>\non-web.fr\n\n// Platform.sh : https://platform.sh\n//
+        Submitted by Nikola Kotur <nikola@platform.sh>\n*.upsun.app\nupsunapp.com\nent.platform.sh\neu.platform.sh\nus.platform.sh\n*.platformsh.site\n*.tst.site\n\n//
+        Pley AB : https://www.pley.com/\n// Submitted by Henning Pohl <infra@pley.com>\npley.games\n\n//
+        Porter : https://porter.run/\n// Submitted by Rudraksh MK <rudi@porter.run>\nonporter.run\n\n//
+        Positive Codes Technology Company : http://co.bn/faq.html\n// Submitted by
+        Zulfais <pc@co.bn>\nco.bn\n\n// Postman, Inc : https://postman.com\n// Submitted
+        by Rahul Dhawan <security@postman.com>\npostman-echo.com\npstmn.io\nmock.pstmn.io\nhttpbin.org\n\n//
+        prequalifyme.today : https://prequalifyme.today\n// Submitted by DeepakTiwari
+        deepak@ivylead.io\nprequalifyme.today\n\n// prgmr.com : https://prgmr.com/\n//
+        Submitted by Sarah Newman <owner@prgmr.com>\nxen.prgmr.com\n\n// priv.at :
+        http://www.nic.priv.at/\n// Submitted by registry <lendl@nic.at>\npriv.at\n\n//
+        PROJECT ELIV : https://eliv.kr/\n// Submitted by PROJECT ELIV DomainName Team
+        <team@eliv.kr>\nc01.kr\neliv-api.kr\neliv-cdn.kr\neliv-dns.kr\nmmv.kr\nvki.kr\n\n//
+        project-study : https://project-study.com\n// Submitted by yumenewa <admin@project-study.com>\ndev.project-study.com\n\n//
+        Protonet GmbH : http://protonet.io\n// Submitted by Martin Meier <admin@protonet.io>\nprotonet.io\n\n//
+        PSL Sandbox : https://github.com/groundcat/PSL-Sandbox\n// Submitted by groundcat
+        <psl-sandbox@alumni.upenn.edu>\nplatter-app.dev\n\n// PT Ekossistim Indo Digital
+        : https://e.id\n// Submitted by Eid Team <support@corp.e.id>\ne.id\n\n// Publication
+        Presse Communication SARL : https://ppcom.fr\n// Submitted by Yaacov Akiba
+        Slama <admin@chirurgiens-dentistes-en-france.fr>\nchirurgiens-dentistes-en-france.fr\nbyen.site\n\n//
+        PublicZone : https://publiczone.org/\n// Submitted by PublicZone NOC Team
+        <noc@publiczone.org>\nnyc.mn\n*.cn.st\n\n// pubtls.org : https://www.pubtls.org\n//
+        Submitted by Kor Nielsen <kor@pubtls.org>\npubtls.org\n\n// PythonAnywhere
+        LLP : https://www.pythonanywhere.com\n// Submitted by Giles Thomas <giles@pythonanywhere.com>\npythonanywhere.com\neu.pythonanywhere.com\n\n//
+        QA2\n// Submitted by Daniel Dent : https://www.danieldent.com/\nqa2.com\n\n//
+        QCX\n// Submitted by Cassandra Beelen <cassandra@beelen.one>\nqcx.io\n*.sys.qcx.io\n\n//
+        QNAP System Inc : https://www.qnap.com\n// Submitted by Nick Chang <cloudadmin@qnap.com>\nmyqnapcloud.cn\nalpha-myqnapcloud.com\ndev-myqnapcloud.com\nmycloudnas.com\nmynascloud.com\nmyqnapcloud.com\n\n//
+        QOTO, Org.\n// Submitted by Jeffrey Phillips Freeman <jeffrey.freeman@qoto.org>\nqoto.io\n\n//
+        Qualifio : https://qualifio.com/\n// Submitted by Xavier De Cock <xdecock@gmail.com>\nqualifioapp.com\n\n//
+        Quality Unit : https://qualityunit.com\n// Submitted by Vasyl Tsalko <vtsalko@qualityunit.com>\nladesk.com\n\n//
+        Qualy : https://qualyhq.com\n// Submitted by Raphael Arias <security@qualyhq.com>\n*.qualyhqpartner.com\n*.qualyhqportal.com\n\n//
+        QuickBackend : https://www.quickbackend.com\n// Submitted by Dani Biro <dani@pymet.com>\nqbuser.com\n\n//
+        Quip : https://quip.com\n// Submitted by Patrick Linehan <plinehan@quip.com>\n*.quipelements.com\n\n//
+        Qutheory LLC : http://qutheory.io\n// Submitted by Jonas Schwartz <jonas@qutheory.io>\nvapor.cloud\nvaporcloud.io\n\n//
+        Rackmaze LLC : https://www.rackmaze.com\n// Submitted by Kirill Pertsev <kika@rackmaze.com>\nrackmaze.com\nrackmaze.net\n\n//
+        Rad Web Hosting : https://radwebhosting.com\n// Submitted by Scott Claeys
+        <s.claeys@radwebhosting.com>\ncloudsite.builders\nmyradweb.net\nservername.us\n\n//
+        Radix FZC : http://domains.in.net\n// Submitted by Gavin Brown <gavin.brown@centralnic.com>\nweb.in\nin.net\n\n//
+        Raidboxes GmbH : https://raidboxes.de\n// Submitted by Auke Tembrink <hostmaster@raidboxes.de>\nmyrdbx.io\nsite.rb-hosting.io\n\n//
+        Railway Corporation : https://railway.com\n// Submitted by Phineas Walton
+        <dns@railway.com>\nup.railway.app\n\n// Rancher Labs, Inc : https://rancher.com\n//
+        Submitted by Vincent Fiduccia <domains@rancher.com>\n*.on-rancher.cloud\n*.on-k3s.io\n*.on-rio.io\n\n//
+        RavPage : https://www.ravpage.co.il\n// Submitted by Roni Horowitz <roni@responder.co.il>\nravpage.co.il\n\n//
+        Read The Docs, Inc : https://www.readthedocs.org\n// Submitted by David Fischer
+        <team@readthedocs.org>\nreadthedocs-hosted.com\nreadthedocs.io\n\n// Red Hat,
+        Inc. OpenShift : https://openshift.redhat.com/\n// Submitted by Tim Kramer
+        <tkramer@rhcloud.com>\nrhcloud.com\n\n// Redgate Software : https://red-gate.com\n//
+        Submitted by Andrew Farries <andrew.farries@red-gate.com>\ninstances.spawn.cc\n\n//
+        Redpanda Data : https://redpanda.com\n// Submitted by Infrastructure Team
+        <security@redpanda.com>\n*.clusters.rdpa.co\n*.srvrless.rdpa.co\n\n// Render
+        : https://render.com\n// Submitted by Anurag Goel <dev@render.com>\nonrender.com\napp.render.com\n\n//
+        Repl.it : https://repl.it\n// Submitted by Lincoln Bergeson <psl@repl.it>\nreplit.app\nid.replit.app\nfirewalledreplit.co\nid.firewalledreplit.co\nrepl.co\nid.repl.co\nreplit.dev\narcher.replit.dev\nbones.replit.dev\ncanary.replit.dev\nglobal.replit.dev\nhacker.replit.dev\nid.replit.dev\njaneway.replit.dev\nkim.replit.dev\nkira.replit.dev\nkirk.replit.dev\nodo.replit.dev\nparis.replit.dev\npicard.replit.dev\npike.replit.dev\nprerelease.replit.dev\nreed.replit.dev\nriker.replit.dev\nsisko.replit.dev\nspock.replit.dev\nstaging.replit.dev\nsulu.replit.dev\ntarpit.replit.dev\nteams.replit.dev\ntucker.replit.dev\nwesley.replit.dev\nworf.replit.dev\nrepl.run\n\n//
+        Resin.io : https://resin.io\n// Submitted by Tim Perry <tim@resin.io>\nresindevice.io\ndevices.resinstaging.io\n\n//
+        RethinkDB : https://www.rethinkdb.com/\n// Submitted by Chris Kastorff <info@rethinkdb.com>\nhzc.io\n\n//
+        Rico Developments Limited : https://adimo.co\n// Submitted by Colin Brown
+        <hello@adimo.co>\nadimo.co.uk\n\n// Riseup Networks : https://riseup.net\n//
+        Submitted by Micah Anderson <micah@riseup.net>\nitcouldbewor.se\n\n// Roar
+        Domains LLC : https://roar.basketball/\n// Submitted by Gavin Brown <gavin.brown@centralnic.com>\naus.basketball\nnz.basketball\n\n//
+        ROBOT PAYMENT INC. : https://www.robotpayment.co.jp/\n// Submitted by Kentaro
+        Takamori <takamori.kentaro@robotpayment.co.jp>\nsubsc-pay.com\nsubsc-pay.net\n\n//
+        Rochester Institute of Technology : http://www.rit.edu/\n// Submitted by Jennifer
+        Herting <jchits@rit.edu>\ngit-pages.rit.edu\n\n// Rocky Enterprise Software
+        Foundation : https://resf.org\n// Submitted by Neil Hanlon <neil@resf.org>\nrocky.page\n\n//
+        Ruhr University Bochum : https://www.ruhr-uni-bochum.de/\n// Submitted by
+        Andreas Jobs <noc@ruhr-uni-bochum.de>\nrub.de\nruhr-uni-bochum.de\nio.noc.ruhr-uni-bochum.de\n\n//
+        Rusnames Limited : http://rusnames.ru/\n// Submitted by Sergey Zotov <admin@rusnames.ru>\n\u0431\u0438\u0437.\u0440\u0443\u0441\n\u043A\u043E\u043C.\u0440\u0443\u0441\n\u043A\u0440\u044B\u043C.\u0440\u0443\u0441\n\u043C\u0438\u0440.\u0440\u0443\u0441\n\u043C\u0441\u043A.\u0440\u0443\u0441\n\u043E\u0440\u0433.\u0440\u0443\u0441\n\u0441\u0430\u043C\u0430\u0440\u0430.\u0440\u0443\u0441\n\u0441\u043E\u0447\u0438.\u0440\u0443\u0441\n\u0441\u043F\u0431.\u0440\u0443\u0441\n\u044F.\u0440\u0443\u0441\n\n//
+        Russian Academy of Sciences\n// Submitted by Tech Support <support@rasnet.ru>\nras.ru\n\n//
+        Sakura Frp : https://www.natfrp.com\n// Submitted by Bobo Liu <support@natfrp.cloud>\nnyat.app\n\n//
+        SAKURA Internet Inc. : https://www.sakura.ad.jp/\n// Submitted by Internet
+        Service Department <rs-vendor-ml@sakura.ad.jp>\n180r.com\ndojin.com\nsakuratan.com\nsakuraweb.com\nx0.com\n2-d.jp\nbona.jp\ncrap.jp\ndaynight.jp\neek.jp\nflop.jp\nhalfmoon.jp\njeez.jp\nmatrix.jp\nmimoza.jp\nivory.ne.jp\nmail-box.ne.jp\nmints.ne.jp\nmokuren.ne.jp\nopal.ne.jp\nsakura.ne.jp\nsumomo.ne.jp\ntopaz.ne.jp\nnetgamers.jp\nnyanta.jp\no0o0.jp\nrdy.jp\nrgr.jp\nrulez.jp\ns3.isk01.sakurastorage.jp\ns3.isk02.sakurastorage.jp\nsaloon.jp\nsblo.jp\nskr.jp\ntank.jp\nuh-oh.jp\nundo.jp\nrs.webaccel.jp\nuser.webaccel.jp\nwebsozai.jp\nxii.jp\nsquares.net\njpn.org\nkirara.st\nx0.to\nfrom.tv\nsakura.tv\n\n//
+        Salesforce.com, Inc. : https://salesforce.com/\n// Submitted by Salesforce
+        Public Suffix List Team <public-suffix-list@salesforce.com>\n*.builder.code.com\n*.dev-builder.code.com\n*.stg-builder.code.com\n*.001.test.code-builder-stg.platform.salesforce.com\n*.aa.crm.dev\n*.ab.crm.dev\n*.ac.crm.dev\n*.ad.crm.dev\n*.ae.crm.dev\n*.af.crm.dev\n*.ci.crm.dev\n*.d.crm.dev\n*.pa.crm.dev\n*.pb.crm.dev\n*.pc.crm.dev\n*.pd.crm.dev\n*.pe.crm.dev\n*.pf.crm.dev\n*.w.crm.dev\n*.wa.crm.dev\n*.wb.crm.dev\n*.wc.crm.dev\n*.wd.crm.dev\n*.we.crm.dev\n*.wf.crm.dev\n\n//
+        Sandstorm Development Group, Inc. : https://sandcats.io/\n// Submitted by
+        Asheesh Laroia <asheesh@sandstorm.io>\nsandcats.io\n\n// Sav.com, LLC : https://marketing.sav.com/\n//
+        Submitted by Mukul Kudegave <mukul@sav.com>\nsav.case\n\n// SBE network solutions
+        GmbH : https://www.sbe.de/\n// Submitted by Norman Meilick <nm@sbe.de>\nlogoip.com\nlogoip.de\n\n//
+        Scaleway : https://www.scaleway.com/\n// Submitted by Scaleway PSL Maintainer
+        <psl-maintainers@scaleway.com>\nfr-par-1.baremetal.scw.cloud\nfr-par-2.baremetal.scw.cloud\nnl-ams-1.baremetal.scw.cloud\ncockpit.fr-par.scw.cloud\nddl.fr-par.scw.cloud\ndtwh.fr-par.scw.cloud\nfnc.fr-par.scw.cloud\nfunctions.fnc.fr-par.scw.cloud\nifr.fr-par.scw.cloud\nk8s.fr-par.scw.cloud\nnodes.k8s.fr-par.scw.cloud\nkafk.fr-par.scw.cloud\nmgdb.fr-par.scw.cloud\nrdb.fr-par.scw.cloud\ns3.fr-par.scw.cloud\ns3-website.fr-par.scw.cloud\nscbl.fr-par.scw.cloud\nwhm.fr-par.scw.cloud\npriv.instances.scw.cloud\npub.instances.scw.cloud\nk8s.scw.cloud\ncockpit.nl-ams.scw.cloud\nddl.nl-ams.scw.cloud\ndtwh.nl-ams.scw.cloud\nifr.nl-ams.scw.cloud\nk8s.nl-ams.scw.cloud\nnodes.k8s.nl-ams.scw.cloud\nkafk.nl-ams.scw.cloud\nmgdb.nl-ams.scw.cloud\nrdb.nl-ams.scw.cloud\ns3.nl-ams.scw.cloud\ns3-website.nl-ams.scw.cloud\nscbl.nl-ams.scw.cloud\nwhm.nl-ams.scw.cloud\ncockpit.pl-waw.scw.cloud\nddl.pl-waw.scw.cloud\ndtwh.pl-waw.scw.cloud\nifr.pl-waw.scw.cloud\nk8s.pl-waw.scw.cloud\nnodes.k8s.pl-waw.scw.cloud\nkafk.pl-waw.scw.cloud\nmgdb.pl-waw.scw.cloud\nrdb.pl-waw.scw.cloud\ns3.pl-waw.scw.cloud\ns3-website.pl-waw.scw.cloud\nscbl.pl-waw.scw.cloud\nscalebook.scw.cloud\nsmartlabeling.scw.cloud\ndedibox.fr\n\n//
+        schokokeks.org GbR : https://schokokeks.org/\n// Submitted by Hanno B\xF6ck
+        <hanno@schokokeks.org>\nschokokeks.net\n\n// Scottish Government : https://www.gov.scot\n//
+        Submitted by Martin Ellis <martin.ellis@gov.scot>\ngov.scot\nservice.gov.scot\n\n//
+        Scry Security : http://www.scrysec.com\n// Submitted by Shante Adam <shante@skyhat.io>\nscrysec.com\n\n//
+        Scrypted : https://scrypted.app\n// Submitted by Koushik Dutta <public-suffix-list@scrypted.app>\nclient.scrypted.io\n\n//
+        Securepoint GmbH : https://www.securepoint.de\n// Submitted by Erik Anders
+        <erik.anders@securepoint.de>\nfirewall-gateway.com\nfirewall-gateway.de\nmy-gateway.de\nmy-router.de\nspdns.de\nspdns.eu\nfirewall-gateway.net\nmy-firewall.org\nmyfirewall.org\nspdns.org\n\n//
+        Seidat : https://www.seidat.com\n// Submitted by Artem Kondratev <accounts@seidat.com>\nseidat.net\n\n//
+        Sellfy : https://sellfy.com\n// Submitted by Yuriy Romadin <contact@sellfy.com>\nsellfy.store\n\n//
+        Sendmsg : https://www.sendmsg.co.il\n// Submitted by Assaf Stern <domains@comstar.co.il>\nminisite.ms\n\n//
+        Senseering GmbH : https://www.senseering.de\n// Submitted by Felix M\xF6nckemeyer
+        <f.moenckemeyer@senseering.de>\nsenseering.net\n\n// Servebolt AS : https://servebolt.com\n//
+        Submitted by Daniel Kjeserud <cloudops@servebolt.com>\nservebolt.cloud\n\n//
+        Service Online LLC : http://drs.ua/\n// Submitted by Serhii Bulakh <support@drs.ua>\nbiz.ua\nco.ua\npp.ua\n\n//
+        Shanghai Accounting Society : https://www.sasf.org.cn\n// Submitted by Information
+        Administration <info@sasf.org.cn>\nas.sh.cn\n\n// Sheezy.Art : https://sheezy.art\n//
+        Submitted by Nyoom <admin@sheezy.art>\nsheezy.games\n\n// Shopblocks : http://www.shopblocks.com/\n//
+        Submitted by Alex Bowers <alex@shopblocks.com>\nmyshopblocks.com\n\n// Shopify
+        : https://www.shopify.com\n// Submitted by Alex Richter <alex.richter@shopify.com>\nmyshopify.com\n\n//
+        Shopit : https://www.shopitcommerce.com/\n// Submitted by Craig McMahon <craig@shopitcommerce.com>\nshopitsite.com\n\n//
+        shopware AG : https://shopware.com\n// Submitted by Jens K\xFCper <cloud@shopware.com>\nshopware.shop\nshopware.store\n\n//
+        Siemens Mobility GmbH\n// Submitted by Oliver Graebner <security@mo-siemens.io>\nmo-siemens.io\n\n//
+        SinaAppEngine : http://sae.sina.com.cn/\n// Submitted by SinaAppEngine <saesupport@sinacloud.com>\n1kapp.com\nappchizi.com\napplinzi.com\nsinaapp.com\nvipsinaapp.com\n\n//
+        Siteleaf : https://www.siteleaf.com/\n// Submitted by Skylar Challand <support@siteleaf.com>\nsiteleaf.net\n\n//
+        Small Technology Foundation : https://small-tech.org\n// Submitted by Aral
+        Balkan <aral@small-tech.org>\nsmall-web.org\n\n// Smallregistry by Promopixel
+        SARL : https://www.smallregistry.net\n// Former AFNIC's SLDs\n// Submitted
+        by J\xE9r\xF4me Lipowicz <support@promopixel.com>\naeroport.fr\navocat.fr\nchambagri.fr\nchirurgiens-dentistes.fr\nexperts-comptables.fr\nmedecin.fr\nnotaires.fr\npharmacien.fr\nport.fr\nveterinaire.fr\n\n//
+        Smoove.io : https://www.smoove.io/\n// Submitted by Dan Kozak <dan@smoove.io>\nvp4.me\n\n//
+        Snowflake Inc : https://www.snowflake.com/\n// Submitted by Sam Haar <psl@snowflake.com>\n*.snowflake.app\n*.privatelink.snowflake.app\nstreamlit.app\nstreamlitapp.com\n\n//
+        Snowplow Analytics : https://snowplowanalytics.com/\n// Submitted by Ian Streeter
+        <ian@snowplowanalytics.com>\ntry-snowplow.com\n\n// Software Consulting Michal
+        Zalewski : https://www.mafelo.com\n// Submitted by Michal Zalewski <security@mafelo.com>\nmafelo.net\n\n//
+        Solana Name Service :  https://sns.id\n// Submitted by Solana Name Service
+        <contact@sns.id>\nsol.site\n\n// Sony Interactive Entertainment LLC : https://sie.com/\n//
+        Submitted by David Coles <david.coles@sony.com>\nplaystation-cloud.com\n\n//
+        SourceHut : https://sourcehut.org\n// Submitted by Drew DeVault <sir@cmpwn.com>\nsrht.site\n\n//
+        SourceLair PC : https://www.sourcelair.com\n// Submitted by Antonis Kalipetis
+        <akalipetis@sourcelair.com>\napps.lair.io\n*.stolos.io\n\n// sourceWAY GmbH
+        : https://sourceway.de\n// Submitted by Richard Reiber <mail@sourceway.de>\n4.at\nmy.at\nmy.de\n*.nxa.eu\nnx.gw\n\n//
+        Spawnbase : https://spawnbase.ai\n// Submitted by Alexander Zuev <security@spawnbase.ai>\nspawnbase.app\n\n//
+        SpeedPartner GmbH : https://www.speedpartner.de/\n// Submitted by Stefan Neufeind
+        <info@speedpartner.de>\ncustomer.speedpartner.de\n\n// Spreadshop (sprd.net
+        AG) : https://www.spreadshop.com/\n// Submitted by Martin Breest <security@spreadshop.com>\nmyspreadshop.at\nmyspreadshop.com.au\nmyspreadshop.be\nmyspreadshop.ca\nmyspreadshop.ch\nmyspreadshop.com\nmyspreadshop.de\nmyspreadshop.dk\nmyspreadshop.es\nmyspreadshop.fi\nmyspreadshop.fr\nmyspreadshop.ie\nmyspreadshop.it\nmyspreadshop.net\nmyspreadshop.nl\nmyspreadshop.no\nmyspreadshop.pl\nmyspreadshop.se\nmyspreadshop.co.uk\n\n//
+        StackBlitz : https://stackblitz.com\n// Submitted by Dominic Elm & Albert
+        Pai <security@bolt.new>\nw-corp-staticblitz.com\nw-credentialless-staticblitz.com\nw-staticblitz.com\nbolt.host\n\n//
+        Stackhero : https://www.stackhero.io\n// Submitted by Adrien Gillon <adrien+public-suffix-list@stackhero.io>\nstackhero-network.com\n\n//
+        STACKIT GmbH & Co. KG : https://www.stackit.de/en/\n// Submitted by STACKIT-DNS
+        Team (Simon Stier) <dns@stackit.cloud>\nruns.onstackit.cloud\nstackit.gg\nstackit.rocks\nstackit.run\nstackit.zone\n\n//
+        Stackryze : https://stackryze.com\n// Submitted by Sudheer Bhuvana <security@stackryze.com>\nsryze.cc\nindevs.in\n\n//
+        Staclar : https://staclar.com\n// Submitted by Q Misell <q@staclar.com>\n//
+        Submitted by Matthias Merkel <matthias.merkel@staclar.com>\nmusician.io\nnovecore.site\n\n//
+        Standard Library : https://stdlib.com\n// Submitted by Jacob Lee <jacob@stdlib.com>\napi.stdlib.com\n\n//
+        statichost.eu : https://www.statichost.eu\n// Submitted by Eric Selin <admin@statichost.eu>\nstatichost.page\n\n//
+        stereosense GmbH : https://www.involve.me\n// Submitted by Florian Burmann
+        <publicsuffix@involve.me>\nfeedback.ac\nforms.ac\nassessments.cx\ncalculators.cx\nfunnels.cx\npaynow.cx\nquizzes.cx\nresearched.cx\ntests.cx\nsurveys.so\n\n//
+        Storacha Network : https://storacha.network\n// Submitted by Alan Shaw <support@storacha.network>\nipfs.storacha.link\nipfs.w3s.link\n\n//
+        Storebase : https://www.storebase.io\n// Submitted by Tony Schirmer <tony@storebase.io>\nstorebase.store\n\n//
+        Storj Labs Inc. : https://storj.io/\n// Submitted by Philip Hutchins <hostmaster@storj.io>\nstorj.farm\n\n//
+        Strapi : https://strapi.io/\n// Submitted by Florent Baldino <security@strapi.io>\nstrapiapp.com\nmedia.strapiapp.com\n\n//
+        Strategic System Consulting (eApps Hosting) : https://www.eapps.com/\n// Submitted
+        by Alex Oancea <aoancea@cloudscale365.com>\nvps-host.net\natl.jelastic.vps-host.net\nnjs.jelastic.vps-host.net\nric.jelastic.vps-host.net\n\n//
+        Streak : https://streak.com\n// Submitted by Blake Kadatz <eng@streak.com>\nstreak-link.com\nstreaklinks.com\nstreakusercontent.com\n\n//
+        Student-Run Computing Facility : https://www.srcf.net/\n// Submitted by Edwin
+        Balani <sysadmins@srcf.net>\nsoc.srcf.net\nuser.srcf.net\n\n// Studenten Net
+        Twente : http://www.snt.utwente.nl/\n// Submitted by Silke Hofstra <syscom@snt.utwente.nl>\nutwente.io\n\n//
+        Sub 6 Limited : http://www.sub6.com\n// Submitted by Dan Miller <dm@sub6.com>\ntemp-dns.com\n\n//
+        Supabase : https://supabase.io\n// Submitted by Supabase Security <psl-maintainers@supabase.io>\nsupabase.co\nrealtime.supabase.co\nstorage.supabase.co\nsupabase.in\nsupabase.net\n\n//
+        Syncloud : https://syncloud.org\n// Submitted by Boris Rybalkin <syncloud@syncloud.it>\nsyncloud.it\n\n//
+        Synology, Inc. : https://www.synology.com/\n// Submitted by Rony Weng <ronyweng@synology.com>\ndscloud.biz\ndirect.quickconnect.cn\ndsmynas.com\nfamilyds.com\ndiskstation.me\ndscloud.me\ni234.me\nmyds.me\nsynology.me\ndscloud.mobi\ndsmynas.net\nfamilyds.net\ndsmynas.org\nfamilyds.org\ndirect.quickconnect.to\nvpnplus.to\n\n//
+        Tabit Technologies Ltd. : https://tabit.cloud/\n// Submitted by Oren Agiv
+        <oren@tabit.cloud>\nmytabit.com\nmytabit.co.il\ntabitorder.co.il\n\n// TAIFUN
+        Software AG : http://taifun-software.de\n// Submitted by Bjoern Henke <dev-server@taifun-software.de>\ntaifun-dns.de\n\n//
+        Tailor Inc. : https://www.tailor.tech\n// Submitted by Ryuzo Yamamoto <psl-maintainers@tailor.tech>\nerp.dev\nweb.erp.dev\n\n//
+        Tailscale Inc. : https://www.tailscale.com\n// Submitted by David Anderson
+        <infra+public-suffix-list@tailscale.com>\nts.net\n*.c.ts.net\n\n// TASK geographical
+        domains : https://task.gda.pl/en/services/for-entrepreneurs/\ngda.pl\ngdansk.pl\ngdynia.pl\nmed.pl\nsopot.pl\n\n//
+        Tave Creative Corp : https://tave.com/\n// Submitted by Adrian Ziemkowski
+        <devops@tave.com>\ntaveusercontent.com\n\n// tawk.to, Inc : https://www.tawk.to\n//
+        Submitted by tawk.to developer team <dev-accounts@tawk.to>\np.tawk.email\np.tawkto.email\n\n//
+        Tche.br : https://tche.br\n// Submitted by Bruno Lorensi <suporte@tche.br>\ntche.br\n\n//
+        team.blue : https://team.blue\n// Submitted by Cedric Dubois <psl-sh@team.blue>\nsite.tb-hosting.com\ndirectwp.eu\n\n//
+        TechEdge Limited: https://www.nic.uk.cc/\n// Submitted by TechEdge Developer
+        <support@nic.uk.cc>\nec.cc\neu.cc\ngu.cc\nuk.cc\nus.cc\n\n// Teckids e.V.
+        : https://www.teckids.org\n// Submitted by Dominik George <dominik.george@teckids.org>\nedugit.io\ns3.teckids.org\n\n//
+        Telebit : https://telebit.cloud\n// Submitted by AJ ONeal <aj@telebit.cloud>\ntelebit.app\ntelebit.io\n*.telebit.xyz\n\n//
+        Teleport : https://goteleport.com\n// Submitted by Rob Picard <security@goteleport.com>\nteleport.sh\n\n//
+        Thingdust AG : https://thingdust.com/\n// Submitted by Adrian Imboden <adi@thingdust.com>\n*.firenet.ch\n*.svc.firenet.ch\nreservd.com\nthingdustdata.com\ncust.dev.thingdust.io\nreservd.dev.thingdust.io\ncust.disrec.thingdust.io\nreservd.disrec.thingdust.io\ncust.prod.thingdust.io\ncust.testing.thingdust.io\nreservd.testing.thingdust.io\n\n//
+        ticket i/O GmbH : https://ticket.io\n// Submitted by Christian Franke <it@ticket.io>\ntickets.io\n\n//
+        Tlon.io : https://tlon.io\n// Submitted by Mark Staarink <mark@tlon.io>\narvo.network\nazimuth.network\ntlon.network\n\n//
+        Tor Project, Inc. : https://torproject.org\n// Submitted by Antoine Beaupr\xE9
+        <anarcat@torproject.org>\ntorproject.net\npages.torproject.net\n\n// TownNews.com
+        : http://www.townnews.com\n// Submitted by Dustin Ward <dward@townnews.com>\ntownnews-staging.com\n\n//
+        TrafficPlex GmbH : https://www.trafficplex.de/\n// Submitted by Phillipp R\xF6ll
+        <phillipp.roell@trafficplex.de>\n12hp.at\n2ix.at\n4lima.at\nlima-city.at\n12hp.ch\n2ix.ch\n4lima.ch\nlima-city.ch\ntrafficplex.cloud\nde.cool\n12hp.de\n2ix.de\n4lima.de\nlima-city.de\n1337.pictures\nclan.rip\nlima-city.rocks\nwebspace.rocks\nlima.zone\n\n//
+        TransIP : https://www.transip.nl\n// Submitted by Rory Breuk <rbreuk@transip.nl>
+        and Cedric Dubois <cedric.dubois@team.blue>\n*.transurl.be\n*.transurl.eu\nsite.transip.me\n*.transurl.nl\n\n//
+        Triton Data Center project : https://tritondatacenter.com\n// Submitted by
+        Triton Data Center staff <tickets@tritondatacenter.com>\n*.triton.zone\n\n//
+        Tunnelmole: https://tunnelmole.com\n// Submitted by Robbie Cahill <support@tunnelmole.com>\ntunnelmole.net\n\n//
+        TuxFamily : http://tuxfamily.org\n// Submitted by TuxFamily administrators
+        <adm@staff.tuxfamily.org>\ntuxfamily.org\n\n// Typedream : https://typedream.com\n//
+        Submitted by Putri Karunia <putri@typedream.com>\ntypedream.app\n\n// Typeform
+        : https://www.typeform.com\n// Submitted by Typeform <ops@typeform.com>\npro.typeform.com\n\n//
+        Uberspace : https://uberspace.de\n// Submitted by Moritz Werner <mwerner@jonaspasche.com>\nuber.space\n\n//
+        UDR Limited : http://www.udr.hk.com\n// Submitted by registry <hostmaster@udr.hk.com>\nhk.com\ninc.hk\nltd.hk\nhk.org\n\n//
+        UK Intis Telecom LTD : https://it.com\n// Submitted by ITComdomains <to@it.com>\nit.com\n\n//
+        Umso Software Inc. : https://www.umso.com\n// Submitted by Alexis Taylor <security@umso.com>\numso.co\n\n//
+        Unison Computing, PBC : https://unison.cloud\n// Submitted by Simon H\xF8jberg
+        <security@unison.cloud>\nunison-services.cloud\n\n// United Gameserver GmbH
+        : https://united-gameserver.de\n// Submitted by Stefan Schwarz <sysadm@united-gameserver.de>\nvirtual-user.de\nvirtualuser.de\n\n//
+        United States Writing Corporation : https://uswriting.co\n// Submitted by
+        Andrew Sampson <security@obj.ag>\nobj.ag\n\n// UNIVERSAL DOMAIN REGISTRY :
+        https://www.udr.org.yt/\n// see also: whois -h whois.udr.org.yt help\n// Submitted
+        by Atanunu Igbunuroghene <publicsuffixlist@udr.org.yt>\nname.pm\nsch.tf\nbiz.wf\nsch.wf\norg.yt\n\n//
+        University of Banja Luka : https://unibl.org\n// Domains for Republic of Srpska
+        administrative entity.\n// Submitted by Marko Ivanovic <kormang@hotmail.rs>\nrs.ba\n\n//
+        University of Bielsko-Biala regional domain : http://dns.bielsko.pl/\n// Submitted
+        by Marcin <dns@ath.bielsko.pl>\nbielsko.pl\n\n// urown.net : https://urown.net\n//
+        Submitted by Hostmaster <hostmaster@urown.net>\nurown.cloud\ndnsupdate.info\n\n//
+        US REGISTRY LLC : http://us.org\n// Submitted by Gavin Brown <gavin.brown@centralnic.com>\nus.org\n\n//
+        V.UA Domain Registry: https://www.v.ua/\n// Submitted by Serhii Rostilo <admin@v.ua>\nv.ua\n\n//
+        Val Town, Inc : https://val.town/\n// Submitted by Tom MacWright <security@val.town>\nval.run\nweb.val.run\n\n//
+        Vercel, Inc : https://vercel.com/\n// Submitted by Laurens Duijvesteijn <security@vercel.com>\nvercel.app\nv0.build\nvercel.dev\nvusercontent.net\nvercel.run\nnow.sh\n\n//
+        VeryPositive SIA : http://very.lv\n// Submitted by Danko Aleksejevs <danko@very.lv>\n2038.io\n\n//
+        Virtual-Info : https://www.virtual-info.info/\n// Submitted by Adnan RIHAN
+        <hostmaster@v-info.info>\nv-info.info\n\n// VistaBlog : https://vistablog.ir/\n//
+        Submitted by Hossein Piri <info@vistablog.ir>\nvistablog.ir\n\n// Viva Republica,
+        Inc. : https://toss.im/\n// Submitted by Deus Team <deus@toss.im>\ndeus-canvas.com\n\n//
+        vivenu GmbH : https://vivenu.com/\n// Submitted by Marvin Frick <ops@vivenu.com>\nvivenushop.com\nvivenushop.dev\n\n//
+        Voorloper.com : https://voorloper.com\n// Submitted by Nathan van Bakel <info@voorloper.com>\nvoorloper.cloud\n\n//
+        Vultr Objects : https://www.vultr.com/products/object-storage/\n// Submitted
+        by Niels Maumenee <storage@vultr.com>\n*.vultrobjects.com\n\n// Waffle Computer
+        Inc., Ltd. : https://docs.waffleinfo.com\n// Submitted by Masayuki Note <masa@blade.wafflecell.com>\nwafflecell.com\n\n//
+        Walrus : https://walrus.xyz\n// Submitted by Max Spector <info@walrus.xyz>\nwal.app\n\n//
+        Wasmer: https://wasmer.io\n// Submitted by Lorentz Kinde <security@wasmer.io>\nwasmer.app\n\n//
+        Webflow, Inc. : https://www.webflow.com\n// Submitted by Webflow Security
+        Team <security@webflow.com>\nwebflow.io\nwebflowtest.io\n\n// WebHare bv :
+        https://www.webhare.com/\n// Submitted by Arnold Hendriks <info@webhare.com>\n*.webhare.dev\n\n//
+        WebHotelier Technologies Ltd : https://www.webhotelier.net/\n// Submitted
+        by Apostolos Tsakpinis <apostolos.tsakpinis@gmail.com>\nbookonline.app\nhotelwithflight.com\nreserve-online.com\nreserve-online.net\n\n//
+        WebPros International, LLC : https://webpros.com/\n// Submitted by Nicolas
+        Rochelemagne <public.suffix@webpros.com>\ncprapid.com\npleskns.com\nwp2.host\npdns.page\nplesk.page\ncpanel.site\nwpsquared.site\n\n//
+        WebWaddle Ltd : https://webwaddle.com/\n// Submitted by Merlin Glander <hostmaster@webwaddle.com>\n*.wadl.top\n\n//
+        Western Digital Technologies, Inc : https://www.wdc.com\n// Submitted by Jung
+        Jin <jungseok.jin@wdc.com>\nremotewd.com\n\n// Whatbox Inc. : https://whatbox.ca/\n//
+        Submitted by Anthony Ryan <servers@whatbox.ca>\nbox.ca\n\n// WIARD Enterprises
+        : https://wiardweb.com\n// Submitted by Kidd Hustle <kiddhustle@wiardweb.com>\npages.wiardweb.com\n\n//
+        Wikimedia Foundation : https://wikitech.wikimedia.org\n// Submitted by Timo
+        Tijhof <noc@wikimedia.org>\ntoolforge.org\nwmcloud.org\nbeta.wmcloud.org\nwmflabs.org\n\n//
+        William Harrison : https://wharrison.com.au\n// Submitted by William Harrison
+        <security@hrsn.net>\nvps.hrsn.au\nhrsn.dev\nis-a.dev\nlocalcert.net\n\n//
+        Windsurf : https://windsurf.com\n// Submitted by Douglas Chen <psl@windsurf.com>\nwindsurf.app\nwindsurf.build\n\n//
+        WirelessCar : https://wirelesscar.com\n// Submitted by Martin Lindberg <drive-platform@wirelesscar.com>\ndrive-platform.com\ndrive-platform.io\n\n//
+        WISP : https://wisp.gg\n// Submitted by Stepan Fedotov <stepan@wisp.gg>\npanel.gg\ndaemon.panel.gg\n\n//
+        Wix.com, Inc. : https://www.wix.com\n// Submitted by Shahar Talmi / Alon Kochba
+        <publicsuffixlist@wix.com>\nbase44.app\nbase44-sandbox.com\nwixsite.com\nwixstudio.com\neditorx.io\nwixstudio.io\nwix.run\n\n//
+        Wizard Zines : https://wizardzines.com\n// Submitted by Julia Evans <julia@wizardzines.com>\nmesswithdns.com\n\n//
+        WoltLab GmbH : https://www.woltlab.com\n// Submitted by Tim D\xFCsterhus <security@woltlab.cloud>\nwoltlab-demo.com\nmyforum.community\ncommunity-pro.de\ndiskussionsbereich.de\ncommunity-pro.net\nmeinforum.net\n\n//
+        Woods Valldata : https://www.woodsvalldata.co.uk/\n// Submitted by Chris Whittle
+        <chris.whittle@woodsvalldata.co.uk>\naffinitylottery.org.uk\nraffleentry.org.uk\nweeklylottery.org.uk\n\n//
+        WP Engine : https://wpengine.com/\n// Submitted by Michael Smith <michael.smith@wpengine.com>\n//
+        Submitted by Brandon DuRette <brandon.durette@wpengine.com>\nwpenginepowered.com\njs.wpenginepowered.com\n\n//
+        XenonCloud GbR : https://xenoncloud.net\n// Submitted by Julian Uphoff <publicsuffixlist@xenoncloud.net>\n*.xenonconnect.de\nhalf.host\n\n//
+        XnBay Technology : http://www.xnbay.com/\n// Submitted by XnBay Developer
+        <developer.xncloud@gmail.com>\nxnbay.com\nu2.xnbay.com\nu2-local.xnbay.com\n\n//
+        XS4ALL Internet bv : https://www.xs4all.nl/\n// Submitted by Daniel Mostertman
+        <unixbeheer+publicsuffix@xs4all.net>\ncistron.nl\ndemon.nl\nxs4all.space\n\n//
+        xTool : https://xtool.com\n// Submitted by Echo <admin@xtool.com>\nxtooldevice.com\n\n//
+        Yandex.Cloud LLC : https://cloud.yandex.com\n// Submitted by Alexander Lodin
+        <security+psl@yandex-team.ru>\nyandexcloud.net\nstorage.yandexcloud.net\nwebsite.yandexcloud.net\nsourcecraft.site\n\n//
+        YesCourse Pty Ltd : https://yescourse.com\n// Submitted by Atul Bhouraskar
+        <atul@yescourse.com>\nofficial.academy\n\n// Yola : https://www.yola.com/\n//
+        Submitted by Stefano Rivera <stefano@yola.com>\nyolasite.com\n\n// Yunohost
+        : https://yunohost.org\n// Submitted by Valentin Grimaud <security@yunohost.org>\nynh.fr\nnohost.me\nnoho.st\n\n//
+        ZaNiC : http://www.za.net/\n// Submitted by registry <hostmaster@nic.za.net>\nza.net\nza.org\n\n//
+        ZAP-Hosting GmbH & Co. KG : https://zap-hosting.com\n// Submitted by Julian
+        Alker <security@zap-hosting.com>\nzap.cloud\n\n// Zeabur : https://zeabur.com/\n//
+        Submitted by Zeabur Team <contact@zeabur.com>\nzeabur.app\n\n// Zerops : https://zerops.io/\n//
+        Submitted by Zerops Team <security@zerops.io>\n*.zerops.app\n\n// Zine EOOD
+        : https://zine.bg/\n// Submitted by Martin Angelov <martin@zine.bg>\nbss.design\n\n//
+        Zitcom A/S : https://www.zitcom.dk\n// Submitted by Emil Stahl <esp@zitcom.dk>\nbasicserver.io\nvirtualserver.io\nenterprisecloud.nu\n\n//
+        Zone.ID: https://zone.id\n// Submitted by Gx1.org <security@gx1.org>\nzone.id\nnett.to\n\n//
+        ZoneABC : https://zoneabc.net\n// Submitted by ZoneABC Team <support@zoneabc.net>\nzabc.net\n\n//
+        ===END PRIVATE DOMAINS===\n"
+    headers:
+      Accept-Ranges:
+      - none
+      Age:
+      - '29851'
+      Alt-Svc:
+      - clear
+      Cache-Control:
+      - public,max-age=86400
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '91698'
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Date:
+      - Sat, 18 Apr 2026 11:14:36 GMT
+      ETag:
+      - W/"e5fadd6e909efbc9675279352d438789"
+      Last-Modified:
+      - Thu, 16 Apr 2026 05:57:06 GMT
+      Server:
+      - UploadServer
+      Vary:
+      - Accept-Encoding
+      X-GUploader-UploadID:
+      - AMNfjG1lTpVjRQaYS4rVjwkJEsKV-Vf26_Cf0FKyuUbHSQjgsOVXRE_5Et763Pmj-bQMXAjR0Ja7ago
+      access-control-allow-origin:
+      - '*'
+      content-security-policy:
+      - default-src 'none'; img-src 'self'; script-src 'unsafe-inline'; style-src
+        'self'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - DENY
+      x-goog-generation:
+      - '1776319026746627'
+      x-goog-hash:
+      - crc32c=JzvImQ==
+      - md5=5frdbpCe+8lnUnk1LUOHiQ==
+      x-goog-metageneration:
+      - '1'
+      x-goog-storage-class:
+      - STANDARD
+      x-goog-stored-content-encoding:
+      - identity
+      x-goog-stored-content-length:
+      - '332264'
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
## Summary

Adds the missing VCR cassette for \`test_hyperlinks::test_single\`. After the uv migration (PR #542), \`tldextract\` resolved to a newer version that fetches \`https://publicsuffix.org/list/public_suffix_list.dat\` at extraction time. The hyperlinks test had no cassette on disk, so VCR in \`--vcr-record=none\` mode failed on the unrecorded call.

Recorded locally with:

    uv run pytest tests/test_hyperlinks.py --vcr-record=new_episodes

Playwright's in-browser requests bypass VCR, so the cassette only captures the tldextract suffix-list fetch (~2,400 lines).

## Test plan

- [x] Locally: \`uv run pytest tests/test_hyperlinks.py -sv\` passes with \`--vcr-record=none\`
- [ ] CI test-python matrix passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)